### PR TITLE
Proxy graphql request and drop referer header

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM node:10.8.0
 RUN npm -g config set user root
 RUN npm install -g bs-platform@4.0.3
 WORKDIR /usr/src
+RUN echo "{}" > package.json && \ 
+    npm install --no-save cypress && rm -rf node_modules && rm package.json
 COPY client/package-lock.json client/package.json ./
 RUN npm link bs-platform
 RUN npm install

--- a/client/src/Config.re
+++ b/client/src/Config.re
@@ -1,24 +1,8 @@
-open Utils;
-
 let authDomain = "/api";
+let graphqlEndpoint = "/api/graphql";
 
 let stagingHost = "staging.sketch.sh";
 let productionHost = "sketch.sh";
-let graphqlEndpoint =
-  env == "production" ?
-    {
-      open Webapi.Dom;
-      let host = location->Location.host;
-
-      if (host == stagingHost) {
-        "https://rtop-server.herokuapp.com/v1alpha1/graphql";
-      } else if (host == productionHost) {
-        "https://sketch-graphql.herokuapp.com/v1alpha1/graphql";
-      } else {
-        "/graphql";
-      };
-    } :
-    "/graphql";
 
 let anonymousUserId = "anonymous";
 

--- a/server/Makefile
+++ b/server/Makefile
@@ -35,4 +35,10 @@ psql:
 	# Access psql of a running container
 	docker exec -it server_postgres_1 psql -U postgres
 
-.PHONY: migrate save update-schema clear reset prod-migrate staging-migrate
+dev:
+	docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d
+
+dev-build:
+	docker-compose -f docker-compose.yml -f docker-compose.dev.yml build
+
+.PHONY: migrate save update-schema clear reset prod-migrate staging-migrate dev

--- a/server/auth/config.js
+++ b/server/auth/config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  graphqlEndpoint: process.env.HASURA_ENDPOINT,
+  jwtToken: process.env.JWT_TOKEN,
+};

--- a/server/auth/hasura-binding.js
+++ b/server/auth/hasura-binding.js
@@ -7,13 +7,13 @@ const { setContext } = require("apollo-link-context");
 const { makeRemoteExecutableSchema } = require("graphql-tools");
 const jwt = require("jsonwebtoken");
 
-const graphqlEndpoint = process.env.HASURA_ENDPOINT;
+const { graphqlEndpoint, jwtToken } = require("./config");
 
 const selfSignedToken = jwt.sign(
   {
     role: "auth_service",
   },
-  process.env.JWT_TOKEN
+  jwtToken
 );
 
 const httpLink = createHttpLink({
@@ -26,8 +26,8 @@ const authLink = setContext((_, { headers }) => {
     headers: {
       ...headers,
       authorization: `Bearer ${selfSignedToken}`,
-    }
-  }
+    },
+  };
 });
 
 const errorLink = onError(({ graphQLErrors, networkError }) => {

--- a/server/auth/package-lock.json
+++ b/server/auth/package-lock.json
@@ -674,6 +674,11 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
+    "es6-promise": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+      "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
+    },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -789,6 +794,26 @@
         "type-is": "~1.6.16",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
+      }
+    },
+    "express-http-proxy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/express-http-proxy/-/express-http-proxy-1.2.0.tgz",
+      "integrity": "sha512-HefDxJyPLTtVqQXYhniN0JCS3ibyDwxvIjrwTGqXUeChdeTz9+Lo9LgKHJRTqTIp8wQeknM+W52v/+/NCm4IIw==",
+      "requires": {
+        "debug": "^3.0.1",
+        "es6-promise": "^4.1.1",
+        "raw-body": "^2.3.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "extend-shallow": {

--- a/server/auth/package.json
+++ b/server/auth/package.json
@@ -18,6 +18,7 @@
     "apollo-link-http": "^1.5.4",
     "dotenv": "^6.0.0",
     "express": "^4.16.3",
+    "express-http-proxy": "^1.2.0",
     "graphql": "^0.13.2",
     "graphql-binding": "^2.1.1",
     "graphql-tag": "^2.9.2",

--- a/server/auth/server.js
+++ b/server/auth/server.js
@@ -9,6 +9,8 @@ const GitHubStrategy = require("passport-github2").Strategy;
 const checkUserInfo = require("./checkUserInfo");
 const nanoidGenerate = require("nanoid/generate");
 const morgan = require("morgan");
+const proxy = require("express-http-proxy");
+const { graphqlEndpoint } = require("./config");
 
 let generateId = () =>
   nanoidGenerate(
@@ -137,5 +139,18 @@ app.get("/api/auth/webhook", (req, res) => {
     }
   });
 });
+
+app.post(
+  "/api/graphql",
+  proxy(graphqlEndpoint, {
+    proxyReqPathResolver: function(req) {
+      return "/v1alpha1/graphql";
+    },
+    proxyReqOptDecorator: function(proxyReqOpts, srcReq) {
+      proxyReqOpts.headers["Referer"] = "";
+      return proxyReqOpts;
+    },
+  })
+);
 
 module.exports = app;


### PR DESCRIPTION
This fixes #92 
Heroku router has a hard 8KB limit on headers size which is very large for normal http requests

But sketch embed content directly into the url so this become problem as url is added in headers.referer

I added a simple proxy feature that will drop referer header completely. 