### PR TITLE
feat: Deleting animation

### DIFF
--- a/client/cypress/integration/rtop/note.spec.js
+++ b/client/cypress/integration/rtop/note.spec.js
@@ -301,35 +301,106 @@ context("Block controls", () => {
     assertCodeBlocks(2);
     assertTextBlocks(1);
   });
-  it("should be able to delete block", () => {
-    cy.visit("new/reason");
-    assertBlocks(1);
-    cy.get(".block__container")
-      .first()
-      .find(`button[aria-label="Add text block"]`)
-      .click();
-    cy.get(".block__container")
-      .first()
-      .find(`button[aria-label="Add text block"]`)
-      .click();
-    cy.get(".block__container")
-      .first()
-      .find(`button[aria-label="Add text block"]`)
-      .click();
-    cy.get(".block__container")
-      .eq(1)
-      .find(`button[aria-label="Add code block"]`)
-      .click();
+  context("Block delete and restore", () => {
+    it("delete block -> timeout 10 seconds -> delete permantely", () => {
+      cy.visit("new/reason");
+      shortcut("{shift}{enter}");
+      shortcut("{shift}{enter}");
+      shortcut("{shift}{enter}");
+      shortcut("{shift}{enter}");
+      shortcut("{shift}{enter}");
 
-    assertCodeBlocks(2);
-    assertTextBlocks(3);
+      assertCodeBlocks(6);
 
-    cy.get(".block__container")
-      .eq(1)
-      .find(`button[aria-label="Delete block"]`)
-      .click();
-    assertCodeBlocks(2);
-    assertTextBlocks(2);
+      cy.get(".block__container")
+        .eq(1)
+        .find(`button[aria-label="Delete block"]`)
+        .click();
+
+      assertCodeBlocks(5);
+      cy.get(".block__container")
+        .eq(1)
+        .find(".block__deleted", { timeout: 10000 })
+        .should("not.exist");
+    });
+    it.only("have restore button in toolbar as well", () => {
+      cy.visit("new/reason");
+      shortcut("{shift}{enter}");
+      shortcut("{shift}{enter}");
+
+      assertCodeBlocks(3);
+
+      cy.get(".block__container")
+        .eq(1)
+        .find(".block__controls")
+        .find(`button[aria-label="Delete block"]`)
+        .click();
+      assertCodeBlocks(2);
+
+      cy.get(".block__container")
+        .eq(1)
+        .find(".block__controls")
+        .find(`button[aria-label="Delete block"]`)
+        .should("not.exist");
+
+      cy.get(".block__container")
+        .eq(1)
+        .find(".block__controls")
+        .find(`button[aria-label="Restore block"]`)
+        .click();
+      assertCodeBlocks(3);
+    });
+    it("can restore temporaty deleted block", () => {
+      cy.visit("new/reason");
+      shortcut("{shift}{enter}");
+      shortcut("{shift}{enter}");
+      shortcut("{shift}{enter}");
+      shortcut("{shift}{enter}");
+      shortcut("{shift}{enter}");
+
+      assertCodeBlocks(6);
+
+      cy.get(".block__container")
+        .eq(1)
+        .find(`button[aria-label="Delete block"]`)
+        .click();
+      assertCodeBlocks(5);
+
+      cy.get(".block__container")
+        .eq(1)
+        .find(".block__deleted")
+        .find(`button[aria-label="Restore block"]`)
+        .click();
+      assertCodeBlocks(6);
+    });
+    it("remove temporary deleted block from execution", () => {
+      cy.visit("new/reason");
+      cy.get(".block__container")
+        .eq(0)
+        .as("block1")
+        .find("textarea")
+        .as("code1")
+        .type("let a = 1;", { force: true });
+      shortcut("{shift}{enter}");
+      assertCodeBlocks(2);
+      cy.get(".block__container")
+        .eq(1)
+        .as("block2")
+        .find("textarea")
+        .as("code2")
+        .type("print_int(a);", { force: true });
+      shortcut("{ctrl}{enter}");
+      assertValue(2);
+
+      cy.get("@block1")
+        .find(`button[aria-label="Delete block"]`)
+        .click();
+      assertCodeBlocks(1);
+      shortcut("{ctrl}{enter}");
+
+      assertValue(0);
+      assertErrorsOrWarnings(1);
+    });
   });
 });
 

--- a/client/cypress/integration/rtop/note.spec.js
+++ b/client/cypress/integration/rtop/note.spec.js
@@ -323,7 +323,7 @@ context("Block controls", () => {
         .find(".block__deleted", { timeout: 10000 })
         .should("not.exist");
     });
-    it.only("have restore button in toolbar as well", () => {
+    it("have restore button in toolbar as well", () => {
       cy.visit("new/reason");
       shortcut("{shift}{enter}");
       shortcut("{shift}{enter}");
@@ -400,6 +400,23 @@ context("Block controls", () => {
 
       assertValue(0);
       assertErrorsOrWarnings(1);
+    });
+
+    it("sync line number when temporary block shows up", () => {
+      cy.visit("new/reason");
+      shortcut("{shift}{enter}");
+      shortcut("{shift}{enter}");
+      assertCodeBlocks(3);
+
+      cy.get(".block__container")
+        .eq(1)
+        .find(`button[aria-label="Delete block"]`)
+        .click();
+      assertCodeBlocks(2);
+
+      cy.window().then(win => {
+        expect(win.editor.getOption("firstLineNumber")).to.equal(2);
+      });
     });
   });
 });

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,3 +1,4 @@
+
 {
   "name": "rtop",
   "version": "0.1.0",

--- a/client/src_analyzer/Worker_Types.re
+++ b/client/src_analyzer/Worker_Types.re
@@ -1,17 +1,3 @@
-module CompilerErrorMessage = {
-  /*
-   Ocaml's parse location is really weird:
-   - Line: 1-based
-   - Col: 0-based
-   */
-  type pos = Worker_Evaluator.Types.pos;
-  let mkPos = Worker_Evaluator.Types.pos;
-  type content = {
-    o_content: string,
-    o_loc: (pos, pos),
-  };
-};
-
 type pos = {
   line: int,
   col: int,

--- a/client/src_editor/Editor_Blocks.css
+++ b/client/src_editor/Editor_Blocks.css
@@ -47,3 +47,68 @@
 .block__controls--button:last-of-type {
   margin-right: 0;
 }
+
+/* ////////// Deleted block */
+.block__deleted {
+  margin-left: var(--cm-gutter-width);
+  border-radius: 4px;
+  padding: var(--space4);
+  background: #feefb3;
+  text-align: center;
+  font-size: var(--f4);
+  position: relative;
+}
+.block__deleted h3 {
+  margin: var(--space2) 0;
+}
+.block__deleted p {
+  margin: 0;
+}
+.block__deleted--progress {
+  width: 100%;
+  position: absolute;
+  background: rgba(0, 0, 0, 0.2);
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  animation: width 10s linear forwards;
+  opacity: 1;
+  z-index: 1;
+}
+@keyframes width {
+  0% {
+    width: 100%;
+  }
+  100% {
+    width: 0;
+  }
+}
+.block__deleted--active {
+  width: 0;
+  opacity: 1;
+}
+.block__deleted--buttons {
+  display: flex;
+  justify-content: center;
+  margin-top: var(--space3);
+}
+.block__deleted--buttons button {
+  z-index: 2;
+  outline: none;
+  display: flex;
+  padding: var(--space3);
+  border: 0;
+  border-radius: 4px;
+  background-color: color-mod(#feefb3 lightness(+6%));
+  transition: background-color 100ms ease-in-out;
+  font-size: var(--f4);
+
+  & svg {
+    margin-right: var(--space2);
+  }
+}
+
+.block__deleted--buttons button:hover {
+  background-color: color-mod(#feefb3 shade(10%))
+}

--- a/client/src_editor/Editor_Blocks.css
+++ b/client/src_editor/Editor_Blocks.css
@@ -53,7 +53,7 @@
   margin-left: var(--cm-gutter-width);
   border-radius: 4px;
   padding: var(--space4);
-  background: #feefb3;
+  background: lightblue;
   text-align: center;
   font-size: var(--f4);
   position: relative;
@@ -67,7 +67,7 @@
 .block__deleted--progress {
   width: 100%;
   position: absolute;
-  background: rgba(0, 0, 0, 0.2);
+  background: rgba(0, 0, 0, 0.1);
   top: 0;
   right: 0;
   bottom: 0;
@@ -101,7 +101,7 @@
   padding: var(--space3);
   border: 0;
   border-radius: 4px;
-  background-color: color-mod(#feefb3 lightness(+6%));
+  background-color: color-mod(lightblue lightness(-6%));
   transition: background-color 100ms ease-in-out;
   font-size: var(--f4);
   cursor: pointer;
@@ -112,5 +112,5 @@
 }
 
 .block__deleted--buttons button:hover {
-  background-color: color-mod(#feefb3 shade(10%));
+  background-color: color-mod(lightblue tint(20%));
 }

--- a/client/src_editor/Editor_Blocks.css
+++ b/client/src_editor/Editor_Blocks.css
@@ -48,7 +48,7 @@
   margin-right: 0;
 }
 
-/* ////////// Deleted block */
+/* ////////// Deleted block //////////////// */
 .block__deleted {
   margin-left: var(--cm-gutter-width);
   border-radius: 4px;
@@ -78,12 +78,13 @@
 }
 @keyframes width {
   0% {
-    width: 100%;
-  }
-  100% {
     width: 0;
   }
+  100% {
+    width: 100%;
+  }
 }
+
 .block__deleted--active {
   width: 0;
   opacity: 1;
@@ -103,6 +104,7 @@
   background-color: color-mod(#feefb3 lightness(+6%));
   transition: background-color 100ms ease-in-out;
   font-size: var(--f4);
+  cursor: pointer;
 
   & svg {
     margin-right: var(--space2);
@@ -110,5 +112,5 @@
 }
 
 .block__deleted--buttons button:hover {
-  background-color: color-mod(#feefb3 shade(10%))
+  background-color: color-mod(#feefb3 shade(10%));
 }

--- a/client/src_editor/Editor_Blocks.re
+++ b/client/src_editor/Editor_Blocks.re
@@ -548,7 +548,9 @@ let make =
                     "It will be permanently deleted after 10 seconds"->str
                   </p>
                   <div className="block__deleted--buttons">
-                    <button onClick=(_ => send(Block_Restore(b_id)))>
+                    <button
+                      onClick=(_ => send(Block_Restore(b_id)))
+                      ariaLabel="Restore block">
                       <Fi.RefreshCw />
                       "Restore"->str
                     </button>

--- a/client/src_editor/Editor_Blocks.re
+++ b/client/src_editor/Editor_Blocks.re
@@ -209,14 +209,18 @@ let make =
         ReasonReact.NoUpdate;
       };
     | Block_Execute(focusNextBlock) =>
-      let allCodeBlocks =
+      let allCodeToExecute =
         state.blocks
         ->(
-            Belt.Array.reduceU([], (. acc, {b_id, b_data}) =>
-              switch (b_data) {
-              | B_Text(_) => acc
-              | B_Code({bc_value}) => [(b_id, bc_value), ...acc]
-              }
+            Belt.Array.reduceU([], (. acc, {b_id, b_data, b_deleted}) =>
+              b_deleted ?
+                acc :
+                (
+                  switch (b_data) {
+                  | B_Text(_) => acc
+                  | B_Code({bc_value}) => [(b_id, bc_value), ...acc]
+                  }
+                )
             )
           )
         ->Belt.List.reverse;
@@ -226,7 +230,7 @@ let make =
         (
           self =>
             Js.Promise.(
-              Editor_Worker.executeMany(. lang, allCodeBlocks)
+              Editor_Worker.executeMany(. lang, allCodeToExecute)
               |> then_(results => {
                    results
                    ->(

--- a/client/src_editor/Editor_Blocks.re
+++ b/client/src_editor/Editor_Blocks.re
@@ -303,6 +303,7 @@ let make =
           ->syncLineNumber,
       });
     | Block_QueueDelete(blockId) =>
+      Js.log("queue delete");
       let queueTimeout = (self, b_data) => {
         let timeoutId =
           Js.Global.setTimeout(

--- a/client/src_editor/Editor_Blocks.re
+++ b/client/src_editor/Editor_Blocks.re
@@ -533,85 +533,97 @@ let make =
     },
   render: ({send, state}) =>
     <>
-      <div className="block__container">
-        <div className="block__deleted">
-          <h3> "This block has been removed"->str </h3>
-          <p> "It will be permanently deleted after 10 seconds"->str </p>
-          <div className="block__deleted--buttons">
-            <button> <Fi.RefreshCw /> "Restore"->str </button>
-          </div>
-          <div className="block__deleted--progress" />
-        </div>
-      </div>
       state.blocks
       ->(
           Belt.Array.mapU((. {b_id, b_data, b_deleted}) =>
-            switch (b_data) {
-            | B_Code({bc_value, bc_widgets, bc_firstLineNumber}) =>
+            b_deleted ?
               <div key=b_id id=b_id className="block__container">
-                <div className="source-editor">
-                  <Editor_CodeBlock
-                    value=(b_deleted ? warning(lang, BTyp_Code) : bc_value)
-                    focused=(
-                      switch (state.focusedBlock) {
-                      | None => None
-                      | Some((id, _blockTyp, changeTyp)) =>
-                        id == b_id ? Some(changeTyp) : None
-                      }
-                    )
-                    onChange=(
-                      (newValue, diff) =>
-                        send(Block_UpdateValue(b_id, newValue, diff))
-                    )
-                    onBlur=(() => send(Block_Blur(b_id)))
-                    onFocus=(() => send(Block_Focus(b_id, BTyp_Code)))
-                    onBlockUp=(() => send(Block_FocusUp(b_id)))
-                    onBlockDown=(() => send(Block_FocusDown(b_id)))
-                    widgets=bc_widgets
-                    readOnly
-                    firstLineNumber=bc_firstLineNumber
-                    lang
-                  />
+                <div className="block__deleted">
+                  <h3> "This block has been removed"->str </h3>
+                  <p>
+                    "It will be permanently deleted after 10 seconds"->str
+                  </p>
+                  <div className="block__deleted--buttons">
+                    <button onClick=(_ => send(Block_Restore(b_id)))>
+                      <Fi.RefreshCw />
+                      "Restore"->str
+                    </button>
+                  </div>
+                  <div className="block__deleted--progress" />
                 </div>
                 <div className="block__controls">
-                  (
-                    readOnly ?
-                      React.null : blockControlsButtons(b_id, b_deleted, send)
-                  )
+                  (blockControlsButtons(b_id, b_deleted, send))
                 </div>
-              </div>
-            | B_Text(text) =>
-              <div key=b_id id=b_id className="block__container">
-                <div className="text-editor">
-                  <Editor_TextBlock
-                    value=(b_deleted ? warning(lang, BTyp_Text) : text)
-                    focused=(
-                      switch (state.focusedBlock) {
-                      | None => None
-                      | Some((id, _blockTyp, changeTyp)) =>
-                        id == b_id ? Some(changeTyp) : None
-                      }
-                    )
-                    onBlur=(() => send(Block_Blur(b_id)))
-                    onFocus=(() => send(Block_Focus(b_id, BTyp_Text)))
-                    onBlockUp=(() => send(Block_FocusUp(b_id)))
-                    onBlockDown=(() => send(Block_FocusDown(b_id)))
-                    onChange=(
-                      (newValue, diff) =>
-                        send(Block_UpdateValue(b_id, newValue, diff))
-                    )
-                    readOnly
-                  />
-                </div>
-                (
-                  readOnly ?
-                    React.null :
-                    <div className="block__controls">
-                      (blockControlsButtons(b_id, b_deleted, send))
+              </div> :
+              (
+                switch (b_data) {
+                | B_Code({bc_value, bc_widgets, bc_firstLineNumber}) =>
+                  <div key=b_id id=b_id className="block__container">
+                    <div className="source-editor">
+                      <Editor_CodeBlock
+                        value=bc_value
+                        focused=(
+                          switch (state.focusedBlock) {
+                          | None => None
+                          | Some((id, _blockTyp, changeTyp)) =>
+                            id == b_id ? Some(changeTyp) : None
+                          }
+                        )
+                        onChange=(
+                          (newValue, diff) =>
+                            send(Block_UpdateValue(b_id, newValue, diff))
+                        )
+                        onBlur=(() => send(Block_Blur(b_id)))
+                        onFocus=(() => send(Block_Focus(b_id, BTyp_Code)))
+                        onBlockUp=(() => send(Block_FocusUp(b_id)))
+                        onBlockDown=(() => send(Block_FocusDown(b_id)))
+                        widgets=bc_widgets
+                        readOnly
+                        firstLineNumber=bc_firstLineNumber
+                        lang
+                      />
                     </div>
-                )
-              </div>
-            }
+                    <div className="block__controls">
+                      (
+                        readOnly ?
+                          React.null :
+                          blockControlsButtons(b_id, b_deleted, send)
+                      )
+                    </div>
+                  </div>
+                | B_Text(text) =>
+                  <div key=b_id id=b_id className="block__container">
+                    <div className="text-editor">
+                      <Editor_TextBlock
+                        value=text
+                        focused=(
+                          switch (state.focusedBlock) {
+                          | None => None
+                          | Some((id, _blockTyp, changeTyp)) =>
+                            id == b_id ? Some(changeTyp) : None
+                          }
+                        )
+                        onBlur=(() => send(Block_Blur(b_id)))
+                        onFocus=(() => send(Block_Focus(b_id, BTyp_Text)))
+                        onBlockUp=(() => send(Block_FocusUp(b_id)))
+                        onBlockDown=(() => send(Block_FocusDown(b_id)))
+                        onChange=(
+                          (newValue, diff) =>
+                            send(Block_UpdateValue(b_id, newValue, diff))
+                        )
+                        readOnly
+                      />
+                    </div>
+                    (
+                      readOnly ?
+                        React.null :
+                        <div className="block__controls">
+                          (blockControlsButtons(b_id, b_deleted, send))
+                        </div>
+                    )
+                  </div>
+                }
+              )
           )
         )
       ->ReasonReact.array

--- a/client/src_editor/Editor_Blocks.re
+++ b/client/src_editor/Editor_Blocks.re
@@ -533,6 +533,16 @@ let make =
     },
   render: ({send, state}) =>
     <>
+      <div className="block__container">
+        <div className="block__deleted">
+          <h3> "This block has been removed"->str </h3>
+          <p> "It will be permanently deleted after 10 seconds"->str </p>
+          <div className="block__deleted--buttons">
+            <button> <Fi.RefreshCw /> "Restore"->str </button>
+          </div>
+          <div className="block__deleted--progress" />
+        </div>
+      </div>
       state.blocks
       ->(
           Belt.Array.mapU((. {b_id, b_data, b_deleted}) =>

--- a/client/src_editor/Editor_Blocks_Utils.re
+++ b/client/src_editor/Editor_Blocks_Utils.re
@@ -141,17 +141,6 @@ let newBlock = {
   b_deleted: false,
 };
 
-let warning = (lang, blockTyp) => {
-  let message = "This block has been removed. It will be permanently deleted after 10 seconds. Click undo to restore.";
-  switch (blockTyp) {
-  | BTyp_Text => "### " ++ message
-  | BTyp_Code =>
-    let open_ = lang == Editor_Types.RE ? "/* " : "(* ";
-    let close = lang == Editor_Types.RE ? " */" : " *)";
-    open_ ++ message ++ close;
-  };
-};
-
 let isEmpty =
   fun
   | B_Code({bc_value}) => String.length(bc_value) == 0

--- a/client/src_editor/Editor_Blocks_Utils.re
+++ b/client/src_editor/Editor_Blocks_Utils.re
@@ -106,24 +106,28 @@ let syncLineNumber: array(block) => array(block) =
     ->(
         Belt.Array.reduceU(
           ([||], 1),
-          (. (acc, firstLineNumber), block) => {
+          (. (acc, nextLineNumber), block) => {
             let {b_id, b_data, b_deleted} = block;
-            switch (b_data) {
-            | B_Code(bcode) =>
-              let {bc_value} = bcode;
-              let newBCode =
-                B_Code({...bcode, bc_firstLineNumber: firstLineNumber});
-              (
-                Belt.Array.concat(
-                  acc,
-                  [|{b_id, b_deleted, b_data: newBCode}|],
-                ),
-                firstLineNumber + bc_value->Utils.js_countLine,
-              );
-            | B_Text(_) => (
-                Belt.Array.concat(acc, [|block|]),
-                firstLineNumber,
-              )
+            if (b_deleted) {
+              (Belt.Array.concat(acc, [|block|]), nextLineNumber);
+            } else {
+              switch (b_data) {
+              | B_Code(bcode) =>
+                let {bc_value} = bcode;
+                let newBCode =
+                  B_Code({...bcode, bc_firstLineNumber: nextLineNumber});
+                (
+                  Belt.Array.concat(
+                    acc,
+                    [|{b_id, b_deleted, b_data: newBCode}|],
+                  ),
+                  nextLineNumber + bc_value->Utils.js_countLine,
+                );
+              | B_Text(_) => (
+                  Belt.Array.concat(acc, [|block|]),
+                  nextLineNumber,
+                )
+              };
             };
           },
         )

--- a/client/src_editor/__tests__/Editor_Json_test.re
+++ b/client/src_editor/__tests__/Editor_Json_test.re
@@ -6,6 +6,14 @@ open Block;
 
 let parse = Js.Json.parseExn;
 
+/*
+ * NOTE: If you change JSON encode/decode
+ * - NEVER change the json value of decode
+ * - You can change the expected ReasonML code
+ * this is to ensure that all saved data will be correctly
+ * decoded in case of an API change
+ * - Encode could be change as will
+ */
 describe("decode", () => {
   open Expect;
   open! Expect.Operators;
@@ -61,16 +69,14 @@ describe("decode", () => {
           "data" : {
             "kind": "code",
             "value": "let a: string = 1;"
-          },
-          "deleted": false
+          }
         },
         {
           "id": "2",
           "data" : {
             "kind": "text",
             "value": "awesome"
-          },
-          "deleted": false
+          }
         }
       ]
     }|}
@@ -105,8 +111,50 @@ describe("decode", () => {
           "data" : {
             "kind": "code",
             "value": "let a: string = 1;"
+          }
+        },
+        {
+          "id": "2",
+          "data" : {
+            "kind": "text",
+            "value": "awesome"
+          }
+        }
+      ]
+    }|}
+      ->parse
+      ->decode;
+
+    expect((lang, blocks))
+    == (
+         RE,
+         [|
+           {
+             b_id: "1",
+             b_data:
+               B_Code({
+                 bc_value: "let a: string = 1;",
+                 bc_firstLineNumber: 1,
+                 bc_widgets: [||],
+               }),
+             b_deleted: false,
+           },
+           {b_id: "2", b_data: B_Text("awesome"), b_deleted: false},
+         |],
+       );
+  });
+  test("decode deleted blocks", () => {
+    let (lang, blocks) =
+      {|{
+      "lang": "RE",
+      "blocks": [
+        {
+          "id": "1",
+          "data" : {
+            "kind": "code",
+            "value": "let a: string = 1;"
           },
-          "deleted": false
+          "deleted": true
         },
         {
           "id": "2",
@@ -133,7 +181,7 @@ describe("decode", () => {
                  bc_firstLineNumber: 1,
                  bc_widgets: [||],
                }),
-             b_deleted: false,
+             b_deleted: true,
            },
            {b_id: "2", b_data: B_Text("awesome"), b_deleted: false},
          |],
@@ -200,7 +248,7 @@ describe("encode", () => {
             "kind": "code",
             "value": "let a: string = 1;"
           },
-          "deleted": false
+          "deleted": true
         },
         {
           "id": "2",
@@ -226,7 +274,7 @@ describe("encode", () => {
                 bc_firstLineNumber: 1,
                 bc_widgets: [||],
               }),
-            b_deleted: false,
+            b_deleted: true,
           },
           {b_id: "2", b_data: B_Text("awesome"), b_deleted: false},
         |],

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -1,3 +1,5 @@
+//@ts-check
+
 const webpack = require("webpack");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const path = require("path");
@@ -11,6 +13,7 @@ const outputDir = path.join(__dirname, "build/");
 
 const isProd = process.env.NODE_ENV === "production";
 
+/** @type webpack.Configuration */
 const base = {
   entry: ["react-hot-loader/patch", "./entry.js"],
   mode: isProd ? "production" : "development",


### PR DESCRIPTION
This PR add a nicer fake block for deleted blocks. Also some integration tests


cc @no-stack-dub-sack when there is only 1 block. Clicking on delete will show a blank code block and the fake block. Is it intended? 

![image](https://user-images.githubusercontent.com/3049054/44592606-46190c80-a7eb-11e8-8af5-5ce37ac08229.png)

TODO
- [x] Tests
- [x] Sync line numbers
- [x] Remove temporary deleted blocks from executing list
