### PR TITLE
fix: allow cmd+/ on mac to toggle comments

### DIFF
--- a/client/src_editor/Editor_CodeBlock.re
+++ b/client/src_editor/Editor_CodeBlock.re
@@ -198,6 +198,8 @@ let make =
 
             Js.Dict.set(key, "Tab", "indentMore");
             Js.Dict.set(key, "Shift-Tab", "indentLess");
+            Js.Dict.set(key, "Cmd-/", "toggleComment");
+            Js.Dict.set(key, "Ctrl-/", "toggleComment");
             key;
           },
           (),

--- a/client/src_editor/Editor_CodeMirror.re
+++ b/client/src_editor/Editor_CodeMirror.re
@@ -150,13 +150,6 @@ let make =
                 if (lineGet(cursor) == lastLine && lastChar == cursor->chGet) {
                   onBlockDown();
                 };
-              | "/" =>
-                if (event->KeyboardEvent.ctrlKey) {
-                  event->KeyboardEventRe.preventDefault;
-                  editor->(CodeMirror.Editor.toggleComment());
-                } else {
-                  ();
-                }
               | _ => ()
               };
             })


### PR DESCRIPTION
As mentioned in the issue, this sets both Ctrl+/ and Cmd+/ to toggle comments, not truly mod key, but this should be helpful in making the transition easier for mac users already used to Ctrl+/. 

With this, we could probably also remove the [toggleComment bindings](https://github.com/Sketch-sh/sketch-sh/blob/0cffa4d962eb955da771852acdddb3c0cf2a4813/client/src_editor/CodeMirror.re#L327) from CodeMirror.re, but not sure if you want to do that or not. 

close #166