### PR TITLE
Refactoring and improve readability of Editor_Blocks

### DIFF
--- a/branding/logo.square.svg
+++ b/branding/logo.square.svg
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 193.86701 193.867"
+   version="1.1"
+   id="svg14"
+   sodipodi:docname="logo.square.svg"
+   inkscape:export-filename="/home/khoa/Pictures/logo.svg.png"
+   inkscape:export-xdpi="570.45038"
+   inkscape:export-ydpi="570.45038"
+   width="193.867"
+   height="193.867"
+   inkscape:version="0.92.3 (d244b95, 2018-08-02)">
+  <metadata
+     id="metadata20">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs18" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1307"
+     inkscape:window-height="744"
+     id="namedview16"
+     showgrid="false"
+     inkscape:zoom="3.0175326"
+     inkscape:cx="89.851076"
+     inkscape:cy="96.933502"
+     inkscape:window-x="59"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg14" />
+  <path
+     d="m 96.934003,0.05598683 c -47.586,0 -86.164,38.57500117 -86.164,86.16300117 V 107.76 c 0,47.589 38.578,86.163 86.164,86.163 H 183.097 V 86.219988 c 0,-47.59 -38.577,-86.16400117 -86.162997,-86.16400117"
+     id="path10"
+     inkscape:connector-curvature="0"
+     style="fill:#1874d5" />
+  <path
+     d="M 151.605,159.219 H 121.687 V 91.603988 c 0,-19.135 -15.569,-34.704 -34.704,-34.704 -19.136,0 -34.705,15.569 -34.705,34.704 H 35.524 c 0,-28.374 23.085,-51.458 51.459,-51.458 28.374,0 51.458,23.084 51.458,51.458 V 142.464 h 13.164 z M 101.343,107.76 c 0,7.932 -6.429,14.36 -14.36,14.36 -7.93,0 -14.36,-6.428 -14.36,-14.36 0,-7.930012 6.43,-14.360012 14.36,-14.360012 7.931,0 14.36,6.43 14.36,14.360012 z"
+     id="path12"
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff" />
+</svg>

--- a/client/cypress/integration/rtop/note.controls.spec.js
+++ b/client/cypress/integration/rtop/note.controls.spec.js
@@ -1,0 +1,205 @@
+/// <reference types="Cypress" />
+
+const faker = require("faker");
+
+import {
+  assertBlocks,
+  assertCodeBlocks,
+  assertTextBlocks,
+  assertStdout,
+  assertErrorsOrWarnings,
+  assertValue,
+  shortcut,
+  assertLastBlockValue,
+  typeTitle,
+  typeBlock,
+} from "../../helpers/editor_helpers";
+
+context("Block controls > Add", () => {
+  it("should add new code block and focus on it", () => {
+    cy.visit("new/reason");
+    assertBlocks(1);
+    assertCodeBlocks(1);
+    assertTextBlocks(0);
+
+    cy.get(".block__container")
+      .first()
+      .find(`button[aria-label="Add code block"]`)
+      .click();
+
+    assertCodeBlocks(2);
+    assertTextBlocks(0);
+
+    cy.get(".block__container")
+      .eq(1)
+      .find("textarea")
+      .focused();
+
+    cy.get(".block__container")
+      .eq(1)
+      .find(`button[aria-label="Add code block"]`)
+      .click();
+
+    assertCodeBlocks(3);
+    assertTextBlocks(0);
+
+    cy.get(".block__container")
+      .eq(2)
+      .find("textarea")
+      .focused();
+  });
+  it("should add new text block and focus on it", () => {
+    cy.visit("new/reason");
+    assertBlocks(1);
+    assertCodeBlocks(1);
+
+    cy.get(".block__container")
+      .first()
+      .find(`button[aria-label="Add text block"]`)
+      .click();
+
+    assertCodeBlocks(1);
+    assertTextBlocks(1);
+
+    cy.get(".block__container")
+      .eq(1)
+      .find("textarea")
+      .focused();
+    cy.get(".block__container")
+      .eq(1)
+      .find(`button[aria-label="Add code block"]`)
+      .click();
+
+    assertCodeBlocks(2);
+    assertTextBlocks(1);
+    cy.get(".block__container")
+      .eq(2)
+      .find("textarea")
+      .focused();
+  });
+});
+
+context("Block controls > delete and restore", () => {
+  it("delete block -> timeout 10 seconds -> delete permantely", () => {
+    cy.visit("new/reason");
+    shortcut("{shift}{enter}");
+    shortcut("{shift}{enter}");
+    shortcut("{shift}{enter}");
+    shortcut("{shift}{enter}");
+    shortcut("{shift}{enter}");
+
+    assertCodeBlocks(6);
+
+    cy.get(".block__container")
+      .eq(1)
+      .find(`button[aria-label="Delete block"]`)
+      .click();
+
+    assertCodeBlocks(5);
+    cy.get(".block__container")
+      .eq(1)
+      .find(".block__deleted", {
+        timeout: 10000,
+      })
+      .should("not.exist");
+  });
+  it("have restore button in toolbar as well", () => {
+    cy.visit("new/reason");
+    shortcut("{shift}{enter}");
+    shortcut("{shift}{enter}");
+
+    assertCodeBlocks(3);
+
+    cy.get(".block__container")
+      .eq(1)
+      .find(".block__controls")
+      .find(`button[aria-label="Delete block"]`)
+      .click();
+    assertCodeBlocks(2);
+
+    cy.get(".block__container")
+      .eq(1)
+      .find(".block__controls")
+      .find(`button[aria-label="Delete block"]`)
+      .should("not.exist");
+
+    cy.get(".block__container")
+      .eq(1)
+      .find(".block__controls")
+      .find(`button[aria-label="Restore block"]`)
+      .click();
+    assertCodeBlocks(3);
+  });
+  it("can restore temporaty deleted block", () => {
+    cy.visit("new/reason");
+    shortcut("{shift}{enter}");
+    shortcut("{shift}{enter}");
+    shortcut("{shift}{enter}");
+    shortcut("{shift}{enter}");
+    shortcut("{shift}{enter}");
+
+    assertCodeBlocks(6);
+
+    cy.get(".block__container")
+      .eq(1)
+      .find(`button[aria-label="Delete block"]`)
+      .click();
+    assertCodeBlocks(5);
+
+    cy.get(".block__container")
+      .eq(1)
+      .find(".block__deleted")
+      .find(`button[aria-label="Restore block"]`)
+      .click();
+    assertCodeBlocks(6);
+  });
+  it("remove temporary deleted block from execution", () => {
+    cy.visit("new/reason");
+    cy.get(".block__container")
+      .eq(0)
+      .as("block1")
+      .find("textarea")
+      .as("code1")
+      .type("let a = 1;", {
+        force: true,
+      });
+    shortcut("{shift}{enter}");
+    assertCodeBlocks(2);
+    cy.get(".block__container")
+      .eq(1)
+      .as("block2")
+      .find("textarea")
+      .as("code2")
+      .type("print_int(a);", {
+        force: true,
+      });
+    shortcut("{ctrl}{enter}");
+    assertValue(2);
+
+    cy.get("@block1")
+      .find(`button[aria-label="Delete block"]`)
+      .click();
+    assertCodeBlocks(1);
+    shortcut("{ctrl}{enter}");
+
+    assertValue(0);
+    assertErrorsOrWarnings(1);
+  });
+
+  it("sync line number when temporary block shows up", () => {
+    cy.visit("new/reason");
+    shortcut("{shift}{enter}");
+    shortcut("{shift}{enter}");
+    assertCodeBlocks(3);
+
+    cy.get(".block__container")
+      .eq(1)
+      .find(`button[aria-label="Delete block"]`)
+      .click();
+    assertCodeBlocks(2);
+
+    cy.window().then(win => {
+      expect(win.editor.getOption("firstLineNumber")).to.equal(2);
+    });
+  });
+});

--- a/client/cypress/integration/rtop/note.spec.js
+++ b/client/cypress/integration/rtop/note.spec.js
@@ -36,7 +36,7 @@ context("keyboard shortcuts", () => {
     cy.get("textarea")
       .first()
       .type("let a: string = 1;", {
-        force: true
+        force: true,
       });
     shortcut("{ctrl}s");
 
@@ -60,7 +60,7 @@ context("keyboard shortcuts", () => {
       .find("textarea")
       .as("block1")
       .type("let a = 1;", {
-        force: true
+        force: true,
       });
 
     shortcut("{shift}{enter}");
@@ -72,7 +72,7 @@ context("keyboard shortcuts", () => {
       .find("textarea")
       .as("block2")
       .type("print_int(a);", {
-        force: true
+        force: true,
       });
 
     shortcut("{shift}{enter}");
@@ -115,7 +115,7 @@ context("keyboard shortcuts", () => {
       .find("textarea")
       .as("block1")
       .type("let a = 1;", {
-        force: true
+        force: true,
       });
 
     shortcut("{shift}{ctrl}{enter}");
@@ -132,7 +132,7 @@ context("keyboard shortcuts", () => {
       .first()
       .find("textarea")
       .type("this thing is working", {
-        force: true
+        force: true,
       });
 
     shortcut("{shift}{ctrl}{enter}");
@@ -153,7 +153,6 @@ context("keyboard shortcuts", () => {
     shortcut("{shift}{ctrl}{enter}");
     assertCodeBlocks(2);
     assertTextBlocks(4);
-
   });
 
   it("ctrl+enter should execute without creating new block", () => {
@@ -164,7 +163,7 @@ context("keyboard shortcuts", () => {
       .find("textarea")
       .as("block1")
       .type("let a: string = 1;", {
-        force: true
+        force: true,
       });
     assertErrorsOrWarnings(0);
 
@@ -173,10 +172,10 @@ context("keyboard shortcuts", () => {
 
     cy.get("@block1")
       .clear({
-        force: true
+        force: true,
       })
       .type("let a = 1;", {
-        force: true
+        force: true,
       });
     assertErrorsOrWarnings(0);
 
@@ -186,176 +185,6 @@ context("keyboard shortcuts", () => {
     cy.get("@block1")
       .get(".widget__value")
       .should("contain", "let a: int = 1;");
-  });
-});
-
-context("Block controls", () => {
-  it("should be able to add new code block", () => {
-    cy.visit("new/reason");
-    assertBlocks(1);
-    assertCodeBlocks(1);
-    assertTextBlocks(0);
-
-    cy.get(".block__container")
-      .first()
-      .find(`button[aria-label="Add code block"]`)
-      .click();
-
-    assertCodeBlocks(2);
-    assertTextBlocks(0);
-
-    cy.get(".block__container")
-      .eq(1)
-      .find(`button[aria-label="Add code block"]`)
-      .click();
-
-    assertCodeBlocks(3);
-    assertTextBlocks(0);
-  });
-  it("should be able to add new text block", () => {
-    cy.visit("new/reason");
-    assertBlocks(1);
-    assertCodeBlocks(1);
-
-    cy.get(".block__container")
-      .first()
-      .find(`button[aria-label="Add text block"]`)
-      .click();
-
-    assertCodeBlocks(1);
-    assertTextBlocks(1);
-
-    cy.get(".block__container")
-      .eq(1)
-      .find(`button[aria-label="Add code block"]`)
-      .click();
-
-    assertCodeBlocks(2);
-    assertTextBlocks(1);
-  });
-  context("Block delete and restore", () => {
-    it("delete block -> timeout 10 seconds -> delete permantely", () => {
-      cy.visit("new/reason");
-      shortcut("{shift}{enter}");
-      shortcut("{shift}{enter}");
-      shortcut("{shift}{enter}");
-      shortcut("{shift}{enter}");
-      shortcut("{shift}{enter}");
-
-      assertCodeBlocks(6);
-
-      cy.get(".block__container")
-        .eq(1)
-        .find(`button[aria-label="Delete block"]`)
-        .click();
-
-      assertCodeBlocks(5);
-      cy.get(".block__container")
-        .eq(1)
-        .find(".block__deleted", {
-          timeout: 10000
-        })
-        .should("not.exist");
-    });
-    it("have restore button in toolbar as well", () => {
-      cy.visit("new/reason");
-      shortcut("{shift}{enter}");
-      shortcut("{shift}{enter}");
-
-      assertCodeBlocks(3);
-
-      cy.get(".block__container")
-        .eq(1)
-        .find(".block__controls")
-        .find(`button[aria-label="Delete block"]`)
-        .click();
-      assertCodeBlocks(2);
-
-      cy.get(".block__container")
-        .eq(1)
-        .find(".block__controls")
-        .find(`button[aria-label="Delete block"]`)
-        .should("not.exist");
-
-      cy.get(".block__container")
-        .eq(1)
-        .find(".block__controls")
-        .find(`button[aria-label="Restore block"]`)
-        .click();
-      assertCodeBlocks(3);
-    });
-    it("can restore temporaty deleted block", () => {
-      cy.visit("new/reason");
-      shortcut("{shift}{enter}");
-      shortcut("{shift}{enter}");
-      shortcut("{shift}{enter}");
-      shortcut("{shift}{enter}");
-      shortcut("{shift}{enter}");
-
-      assertCodeBlocks(6);
-
-      cy.get(".block__container")
-        .eq(1)
-        .find(`button[aria-label="Delete block"]`)
-        .click();
-      assertCodeBlocks(5);
-
-      cy.get(".block__container")
-        .eq(1)
-        .find(".block__deleted")
-        .find(`button[aria-label="Restore block"]`)
-        .click();
-      assertCodeBlocks(6);
-    });
-    it("remove temporary deleted block from execution", () => {
-      cy.visit("new/reason");
-      cy.get(".block__container")
-        .eq(0)
-        .as("block1")
-        .find("textarea")
-        .as("code1")
-        .type("let a = 1;", {
-          force: true
-        });
-      shortcut("{shift}{enter}");
-      assertCodeBlocks(2);
-      cy.get(".block__container")
-        .eq(1)
-        .as("block2")
-        .find("textarea")
-        .as("code2")
-        .type("print_int(a);", {
-          force: true
-        });
-      shortcut("{ctrl}{enter}");
-      assertValue(2);
-
-      cy.get("@block1")
-        .find(`button[aria-label="Delete block"]`)
-        .click();
-      assertCodeBlocks(1);
-      shortcut("{ctrl}{enter}");
-
-      assertValue(0);
-      assertErrorsOrWarnings(1);
-    });
-
-    it("sync line number when temporary block shows up", () => {
-      cy.visit("new/reason");
-      shortcut("{shift}{enter}");
-      shortcut("{shift}{enter}");
-      assertCodeBlocks(3);
-
-      cy.get(".block__container")
-        .eq(1)
-        .find(`button[aria-label="Delete block"]`)
-        .click();
-      assertCodeBlocks(2);
-
-      cy.window().then(win => {
-        expect(win.editor.getOption("firstLineNumber")).to.equal(2);
-      });
-    });
   });
 });
 
@@ -376,7 +205,7 @@ context("Edge cases", () => {
       .find("textarea")
       .as("block1")
       .type("let a = 1;", {
-        force: true
+        force: true,
       });
 
     cy.get("@title")
@@ -396,7 +225,7 @@ context("Edge cases", () => {
       .find("textarea")
       .as("block1")
       .type("let x = 1; let y = 2; let z = 3;", {
-        force: true
+        force: true,
       });
     shortcut("{ctrl}{enter}");
     assertValue(3);
@@ -421,7 +250,7 @@ context("Edge cases", () => {
       .find("textarea")
       .as("block1")
       .type(content, {
-        force: true
+        force: true,
       });
     shortcut("{ctrl}s");
 
@@ -435,7 +264,7 @@ context("Edge cases", () => {
       expect(win.editor.getValue()).to.equal(content);
     });
     cy.get("@block1").type("{ctrl}z", {
-      force: true
+      force: true,
     });
     cy.window().then(win => {
       expect(win.editor.getValue()).to.equal(content);

--- a/client/shared/Utils.re
+++ b/client/shared/Utils.re
@@ -119,8 +119,6 @@ let generateId = () =>
     22,
   );
 
-let pluckAcc = ((acc, _)) => acc;
-
 external toNullable: string => Js.Nullable.t(string) = "%identity";
 
 let inArray = (arr, value) => arr |> Js.Array.indexOf(value) != (-1);

--- a/client/src_editor/Editor_Blocks.re
+++ b/client/src_editor/Editor_Blocks.re
@@ -83,6 +83,12 @@ module Actions = {
         ),
       )
     };
+  /*
+   * Focus up helper
+   * - Find current block index
+   * - If it's the FIRST or not in blocks (should never happen) then ignore
+   * - Else focus on upper block
+   */
   let focusUp = (action, state, blockId) => {
     let blockIndex =
       state.blocks->arrayFindIndex(({b_id}) => blockId == b_id);
@@ -101,6 +107,12 @@ module Actions = {
       });
     };
   };
+  /*
+   * Focus down helper
+   * - Find current block index
+   * - If it's the LAST or not in blocks (should never happen) then ignore
+   * - Else focus on lower block
+   */
   let focusDown = (action, state, blockId) => {
     let length = state.blocks->Belt.Array.length;
     let blockIndex =

--- a/client/src_editor/Editor_Blocks.re
+++ b/client/src_editor/Editor_Blocks.re
@@ -1,3 +1,7 @@
+/*
+ * Tips: Fold code at level 2 would help alot with readability
+ * If you're using VSCode, use <C-K> <C-2>
+ */
 [%%debugger.chrome];
 Modules.require("./Editor_Blocks.css");
 
@@ -734,7 +738,7 @@ let make =
         newSelf.send(Block_ChangeLanguage);
       };
       if (oldSelf.state.blocks !== newSelf.state.blocks) {
-        let cleanBlocksCopy = () =>
+        let cleanBlocksCopyHelper = () =>
           switch (newSelf.state.blocksCopy) {
           | None => ()
           | Some(_) => newSelf.send(Block_CleanBlocksCopy)
@@ -766,11 +770,11 @@ let make =
           | Block_Add(_, _)
           | Block_Restore(_)
           | Block_DeleteQueued(_)
-          | Block_PrettyPrint => cleanBlocksCopy()
+          | Block_PrettyPrint => cleanBlocksCopyHelper()
           | Block_UpdateValue(_, _, diff) =>
             switch (diff->CodeMirror.EditorChange.originGet) {
             | "setValue" => ()
-            | _ => cleanBlocksCopy()
+            | _ => cleanBlocksCopyHelper()
             }
           | _ => ()
           };

--- a/client/src_editor/Editor_Blocks.re
+++ b/client/src_editor/Editor_Blocks.re
@@ -34,6 +34,15 @@ type state = {
   focusedBlock: option((id, blockTyp, focusChangeType)),
 };
 
+module Actions = {
+  let cleanBlocksCopy = (action, state) =>
+    ReasonReact.Update({
+      ...state,
+      blocksCopy: None,
+      stateUpdateReason: Some(action),
+    });
+};
+
 let blockControlsButtons = (blockId, isDeleted, send) =>
   <div className="block__controls--buttons">
     <UI_Balloon message="Add code block" position=Down>
@@ -88,7 +97,7 @@ let make =
       ~onExecute,
       ~registerExecuteCallback=?,
       ~registerShortcut: option(Shortcut.subscribeFun)=?,
-      _children,
+      _children: React.childless,
     ) => {
   let makeInitialState = () => {
     lang,
@@ -218,12 +227,7 @@ let make =
     },
     reducer: (action, state) =>
       switch (action) {
-      | Block_CleanBlocksCopy =>
-        ReasonReact.Update({
-          ...state,
-          blocksCopy: None,
-          stateUpdateReason: Some(action),
-        })
+      | Block_CleanBlocksCopy => Actions.cleanBlocksCopy(action, state)
       | Block_PrettyPrint =>
         switch (lang) {
         | ML =>

--- a/client/src_editor/Editor_Blocks.re
+++ b/client/src_editor/Editor_Blocks.re
@@ -507,7 +507,7 @@ let make =
             ->syncLineNumber,
         });
       | Block_QueueDelete(blockId) =>
-        let queueTimeout = (send, b_data) => {
+        let queueTimeout = send => {
           let timeoutId =
             Js.Global.setTimeout(
               () => send(Block_DeleteQueued(blockId)),
@@ -529,7 +529,7 @@ let make =
                 stateUpdateReason: Some(action),
                 focusedBlock: None,
               },
-              (({send}) => queueTimeout(send, state.blocks[0].b_data)),
+              (({send}) => queueTimeout(send)),
             )
           };
         } else {
@@ -554,9 +554,7 @@ let make =
                   focusedBlock == blockId ? None : state.focusedBlock
                 },
             },
-            (
-              ({send}) => queueTimeout(send, state.blocks[blockIndex].b_data)
-            ),
+            (({send}) => queueTimeout(send)),
           );
         };
       | Block_DeleteQueued(blockId) =>

--- a/client/src_editor/Editor_Blocks.re
+++ b/client/src_editor/Editor_Blocks.re
@@ -35,12 +35,21 @@ type state = {
 };
 
 module Actions = {
+  /*
+   * Clean blocks copy
+   * - This action is trigged when user made a changes to the content
+   * - Because refmt between 2 languages is destructive
+   *   We keep a copy of old state in `state.blocksCopy`
+   *   so when you switch back to original language
+   *   you'll get the original content
+   */
   let cleanBlocksCopy = (action, state) =>
     ReasonReact.Update({
       ...state,
       blocksCopy: None,
       stateUpdateReason: Some(action),
     });
+  /* TODO: Extract common part of prettyPrint and changeLanguage into a new function */
   let prettyPrint = (_action, state) =>
     switch (state.lang) {
     | ML =>
@@ -83,6 +92,104 @@ module Actions = {
         ),
       )
     };
+  let changeLanguage = (action, state) =>
+    switch (state.blocksCopy) {
+    | None =>
+      ReasonReact.UpdateWithSideEffects(
+        {
+          ...state,
+          blocksCopy: Some(state.blocks),
+          stateUpdateReason: Some(action),
+        },
+        (
+          self => {
+            let operation =
+              switch (state.lang) {
+              | ML => Toplevel.Types.ReToMl
+              | RE => Toplevel.Types.MlToRe
+              };
+            let id =
+              Toplevel_Consumer.refmt(
+                operation,
+                self.state.blocks->codeBlockDataPairs,
+                fun
+                | Belt.Result.Error(error) => Notify.error(error)
+                | Belt.Result.Ok({hasError, result}) =>
+                  if (hasError) {
+                    /* TODO: Map syntax error to block position */
+                    Notify.error(
+                      "An error happens while formatting your code. It might be a syntax error",
+                    );
+                  } else {
+                    let result =
+                      result
+                      ->Belt.List.reduce(
+                          [],
+                          (
+                            (acc, {refmt_id, refmt_value}) =>
+                              switch (refmt_value) {
+                              | Ok(code) => [(refmt_id, code), ...acc]
+                              | Error(_) => acc
+                              }
+                          ),
+                        );
+                    self.send(Block_MapRefmtToBlocks(result));
+                  },
+              );
+            self.onUnmount(() => Toplevel_Consumer.cancel(id));
+          }
+        ),
+      )
+    | Some(blocksCopy) =>
+      ReasonReact.UpdateWithSideEffects(
+        {
+          ...state,
+          blocksCopy: None,
+          blocks: blocksCopy,
+          stateUpdateReason: Some(action),
+        },
+        (self => self.send(Block_Execute(false, BTyp_Code))),
+      )
+    };
+  let mapRefmtToBlocks = (action, state, results) =>
+    ReasonReact.UpdateWithSideEffects(
+      {
+        ...state,
+        stateUpdateReason: Some(action),
+        blocks:
+          state.blocks
+          ->(
+              Belt.Array.mapU((. block) => {
+                let {b_data, b_id, b_deleted} = block;
+                b_deleted ?
+                  block :
+                  (
+                    switch (b_data) {
+                    | B_Code(bcode) =>
+                      let mappedBlock =
+                        results
+                        ->Belt.List.getBy((((id, _code)) => id == b_id));
+                      switch (mappedBlock) {
+                      | None => block
+                      | Some((_id, code)) => {
+                          ...block,
+                          b_data:
+                            B_Code({
+                              ...bcode,
+                              /* TODO: Don't remove widgets but executing and replace with latest widget */
+                              bc_widgets: [||],
+                              bc_value: code,
+                            }),
+                        }
+                      };
+                    | B_Text(_) => block
+                    }
+                  );
+              })
+            ),
+      },
+      ({send}) => send(Block_Execute(false, BTyp_Code)),
+    );
   /*
    * Focus up helper
    * - Find current block index
@@ -170,6 +277,318 @@ module Actions = {
                 };
               },
             )
+          )
+        ->syncLineNumber,
+    });
+  };
+  /*
+   * Block Focus and Blur
+   */
+  /* TODO: Why blockTyp is needed? */
+  let focus = (action, state, blockId, blockTyp) =>
+    ReasonReact.Update({
+      ...state,
+      stateUpdateReason: Some(action),
+      focusedBlock: Some((blockId, blockTyp, FcTyp_EditorFocus)),
+    });
+  let blur = (action, state, blockId) =>
+    switch (state.focusedBlock) {
+    | None => ReasonReact.NoUpdate
+    | Some((focusedBlockId, _, _)) =>
+      focusedBlockId == blockId ?
+        ReasonReact.Update({
+          ...state,
+          stateUpdateReason: Some(action),
+          focusedBlock: None,
+        }) :
+        ReasonReact.NoUpdate
+    };
+  /*
+   * Block delete and restore
+   * - QueueDelete:
+   *   + Pressed on BlockControls > DeleteButton
+   *   + Set b_deleted to true and show fake block
+   * - DeleteQueued: Timeout, remove blocks complete
+   */
+  let queueDelete = (action, state, blockId) => {
+    let queueTimeout = self => {
+      let timeoutId =
+        Js.Global.setTimeout(
+          () => self.ReasonReact.send(Block_DeleteQueued(blockId)),
+          10000,
+        );
+      self.onUnmount(() => Js.Global.clearTimeout(timeoutId));
+      self.ReasonReact.send(Block_CaptureQueuedMeta(blockId, timeoutId));
+    };
+    if (isLastBlock(state.blocks)) {
+      switch (isEmpty(state.blocks[0].b_data)) {
+      | true => ReasonReact.NoUpdate
+      | _ =>
+        ReasonReact.UpdateWithSideEffects(
+          {
+            ...state,
+            blocks:
+              [|newBlock, {...state.blocks[0], b_deleted: true}|]
+              ->syncLineNumber,
+            stateUpdateReason: Some(action),
+            focusedBlock: None,
+          },
+          (self => queueTimeout(self)),
+        )
+      };
+    } else {
+      ReasonReact.UpdateWithSideEffects(
+        {
+          ...state,
+          blocks:
+            state.blocks
+            ->(
+                Belt.Array.mapU((. block) => {
+                  let {b_id} = block;
+                  b_id == blockId ? {...block, b_deleted: true} : block;
+                })
+              )
+            ->syncLineNumber,
+          stateUpdateReason: Some(action),
+          focusedBlock:
+            switch (state.focusedBlock) {
+            | None => None
+            | Some((focusedBlock, _, _)) =>
+              focusedBlock == blockId ? None : state.focusedBlock
+            },
+        },
+        self => queueTimeout(self),
+      );
+    };
+  };
+  let deleteQueued = (action, state, blockId) =>
+    if (isLastBlock(state.blocks) || Belt.Array.length(state.blocks) == 0) {
+      ReasonReact.Update({
+        ...state,
+        blocks: [|newBlock|],
+        deletedBlockMeta:
+          state.deletedBlockMeta
+          ->(
+              Belt.Array.keepU((. (timeoutBlockId, _timeoutId)) =>
+                timeoutBlockId != blockId
+              )
+            ),
+        stateUpdateReason: Some(action),
+        focusedBlock: None,
+      });
+    } else {
+      ReasonReact.Update({
+        ...state,
+        blocks:
+          state.blocks
+          ->(Belt.Array.keepU((. {b_id}) => b_id != blockId))
+          ->syncLineNumber,
+        deletedBlockMeta:
+          state.deletedBlockMeta
+          ->(
+              Belt.Array.keepU((. (timeoutBlockId, _timeoutId)) =>
+                timeoutBlockId != blockId
+              )
+            ),
+        stateUpdateReason: Some(action),
+        focusedBlock:
+          switch (state.focusedBlock) {
+          | None => None
+          | Some((focusedBlock, _, _)) =>
+            focusedBlock == blockId ? None : state.focusedBlock
+          },
+      });
+    };
+  let restore = (action, state, blockId) => {
+    let timeoutId =
+      state.deletedBlockMeta
+      ->arrayFind(((timeBlockId, _timeoutId)) => timeBlockId == blockId);
+    switch (timeoutId) {
+    | None => ReasonReact.NoUpdate
+    | Some((_timeoutBlockId, timeoutId)) =>
+      ReasonReact.UpdateWithSideEffects(
+        {
+          ...state,
+          blocks:
+            state.blocks
+            ->(
+                Belt.Array.mapU((. block) => {
+                  let {b_id} = block;
+
+                  b_id == blockId ? {...block, b_deleted: false} : block;
+                })
+              )
+            ->syncLineNumber,
+          deletedBlockMeta:
+            state.deletedBlockMeta
+            ->(
+                Belt.Array.keepU((. (timeBlockId, _timeoutId)) =>
+                  timeBlockId != blockId
+                )
+              ),
+          stateUpdateReason: Some(action),
+        },
+        (_self => Js.Global.clearTimeout(timeoutId)),
+      )
+    };
+  };
+  let captureQueuedMeta = (action, state, blockId, timeoutId) =>
+    ReasonReact.Update({
+      ...state,
+      deletedBlockMeta:
+        Belt.Array.concat(state.deletedBlockMeta, [|(blockId, timeoutId)|]),
+      stateUpdateReason: Some(action),
+    });
+  /*
+   * Execution and helpers
+   * - Execute -> Map results to widgets
+   * - Execute with shortcuts -> Focus on next block,
+   *   if this is last then create new block
+   */
+  let execute = (action, state, focusNextBlock, blockTyp, onExecute, lang) => {
+    let allCodeToExecute = codeBlockDataPairs(state.blocks);
+
+    ReasonReact.UpdateWithSideEffects(
+      {...state, stateUpdateReason: Some(action)},
+      self => {
+        if (focusNextBlock) {
+          self.send(Block_FocusNextBlockOrCreate(blockTyp));
+        };
+        onExecute(true);
+        let id =
+          Toplevel_Consumer.execute(
+            lang,
+            allCodeToExecute,
+            fun
+            | Belt.Result.Error(error) => {
+                onExecute(false);
+                Notify.error(error);
+              }
+            | Belt.Result.Ok(blocks) => {
+                onExecute(false);
+                blocks
+                ->(
+                    Belt.List.forEachU(
+                      (. {Toplevel.Types.id: blockId, result}) => {
+                      let widgets = executeResultToWidget(result);
+                      self.send(Block_AddWidgets(blockId, widgets));
+                    })
+                  );
+              },
+          );
+
+        self.onUnmount(() => Toplevel_Consumer.cancel(id));
+      },
+    );
+  };
+  let addWidgets = (action, state, blockId, widgets) =>
+    ReasonReact.Update({
+      ...state,
+      stateUpdateReason: Some(action),
+      blocks:
+        state.blocks
+        ->(
+            Belt.Array.mapU((. block) => {
+              let {b_id, b_data} = block;
+              if (b_id != blockId) {
+                block;
+              } else {
+                switch (b_data) {
+                | B_Text(_) => block
+                | B_Code(bcode) => {
+                    ...block,
+                    b_data: B_Code({...bcode, bc_widgets: widgets}),
+                  }
+                };
+              };
+            })
+          ),
+    });
+  let focusNextBlockOrCreate = (action, state, blockTyp) => {
+    let blockLength = state.blocks->Belt.Array.length;
+
+    let currentBlockIndex =
+      switch (state.focusedBlock) {
+      | None => blockLength - 1
+      | Some((id, _blockTyp, _)) =>
+        switch (state.blocks->arrayFindIndex((({b_id}) => b_id == id))) {
+        | None => blockLength - 1
+        | Some(index) => index
+        }
+      };
+    let findBlockId = index => {
+      let {b_id, b_data} = state.blocks[index];
+      (b_id, blockDataToBlockTyp(b_data));
+    };
+    if (currentBlockIndex == blockLength - 1) {
+      ReasonReact.SideEffects(
+        ({send}) =>
+          send(Block_Add(findBlockId(currentBlockIndex)->fst, blockTyp)),
+      );
+    } else if (currentBlockIndex < blockLength - 1) {
+      let (nextBlockId, nextBlockTyp) = findBlockId(currentBlockIndex + 1);
+      ReasonReact.Update({
+        ...state,
+        stateUpdateReason: Some(action),
+        focusedBlock:
+          Some((
+            nextBlockId,
+            nextBlockTyp,
+            FcTyp_BlockExecuteAndFocusNextBlock,
+          )),
+      });
+    } else {
+      ReasonReact.NoUpdate;
+    };
+  };
+  /*
+   * Update value
+   * - Clean all widgets below the editing points to avoid stale state
+   */
+  let update = (action, state, blockId, newValue, diff) => {
+    let blockIndex = state.blocks->getBlockIndex(blockId);
+    ReasonReact.Update({
+      ...state,
+      stateUpdateReason: Some(action),
+      blocks:
+        state.blocks
+        ->(
+            Belt.Array.mapWithIndexU((. i, block) => {
+              let {b_data} = block;
+              if (i < blockIndex) {
+                block;
+              } else if (i == blockIndex) {
+                switch (b_data) {
+                | B_Code(bcode) => {
+                    ...block,
+                    b_data:
+                      B_Code({
+                        ...bcode,
+                        bc_value: newValue,
+                        bc_widgets: {
+                          let removeWidgetBelowMe = diff->getFirstLineFromDiff;
+                          let currentWidgets = bcode.bc_widgets;
+                          currentWidgets
+                          ->(
+                              Belt.Array.keepU((. {Widget.lw_line, _}) =>
+                                lw_line < removeWidgetBelowMe
+                              )
+                            );
+                        },
+                      }),
+                  }
+                | B_Text(_) => {...block, b_data: B_Text(newValue)}
+                };
+              } else {
+                switch (b_data) {
+                | B_Text(_) => block
+                | B_Code(bcode) => {
+                    ...block,
+                    b_data: B_Code({...bcode, bc_widgets: [||]}),
+                  }
+                };
+              };
+            })
           )
         ->syncLineNumber,
     });
@@ -362,396 +781,34 @@ let make =
       switch (action) {
       | Block_CleanBlocksCopy => Actions.cleanBlocksCopy(action, state)
       | Block_PrettyPrint => Actions.prettyPrint(action, state)
-      | Block_ChangeLanguage =>
-        switch (state.blocksCopy) {
-        | None =>
-          ReasonReact.UpdateWithSideEffects(
-            {...state, blocksCopy: Some(state.blocks)},
-            (
-              self => {
-                let operation =
-                  switch (state.lang) {
-                  | ML => Toplevel.Types.ReToMl
-                  | RE => Toplevel.Types.MlToRe
-                  };
-                let id =
-                  Toplevel_Consumer.refmt(
-                    operation,
-                    self.state.blocks->codeBlockDataPairs,
-                    fun
-                    | Belt.Result.Error(error) => Notify.error(error)
-                    | Belt.Result.Ok({hasError, result}) =>
-                      if (hasError) {
-                        /* TODO: Map syntax error to block position */
-                        Notify.error(
-                          "An error happens while formatting your code. It might be a syntax error",
-                        );
-                      } else {
-                        let result =
-                          result
-                          ->Belt.List.reduce(
-                              [],
-                              (
-                                (acc, {refmt_id, refmt_value}) =>
-                                  switch (refmt_value) {
-                                  | Ok(code) => [(refmt_id, code), ...acc]
-                                  | Error(_) => acc
-                                  }
-                              ),
-                            );
-                        self.send(Block_MapRefmtToBlocks(result));
-                      },
-                  );
-                self.onUnmount(() => Toplevel_Consumer.cancel(id));
-              }
-            ),
-          )
-        | Some(blocksCopy) =>
-          ReasonReact.UpdateWithSideEffects(
-            {...state, blocksCopy: None, blocks: blocksCopy},
-            (self => self.send(Block_Execute(false, BTyp_Code))),
-          )
-        }
-
+      | Block_ChangeLanguage => Actions.changeLanguage(action, state)
       | Block_MapRefmtToBlocks(results) =>
-        ReasonReact.UpdateWithSideEffects(
-          {
-            ...state,
-            stateUpdateReason: Some(action),
-            blocks:
-              state.blocks
-              ->(
-                  Belt.Array.mapU((. block) => {
-                    let {b_data, b_id, b_deleted} = block;
-                    b_deleted ?
-                      block :
-                      (
-                        switch (b_data) {
-                        | B_Code(bcode) =>
-                          let mappedBlock =
-                            results
-                            ->Belt.List.getBy(
-                                (((id, _code)) => id == b_id),
-                              );
-                          switch (mappedBlock) {
-                          | None => block
-                          | Some((_id, code)) => {
-                              ...block,
-                              b_data:
-                                B_Code({
-                                  ...bcode,
-                                  /* TODO: Don't remove widgets but executing and replace with latest widget */
-                                  bc_widgets: [||],
-                                  bc_value: code,
-                                }),
-                            }
-                          };
-                        | B_Text(_) => block
-                        }
-                      );
-                  })
-                ),
-          },
-          (({send}) => send(Block_Execute(false, BTyp_Code))),
-        )
+        Actions.mapRefmtToBlocks(action, state, results)
       | Block_AddWidgets(blockId, widgets) =>
-        ReasonReact.Update({
-          ...state,
-          stateUpdateReason: Some(action),
-          blocks:
-            state.blocks
-            ->(
-                Belt.Array.mapU((. block) => {
-                  let {b_id, b_data} = block;
-                  if (b_id != blockId) {
-                    block;
-                  } else {
-                    switch (b_data) {
-                    | B_Text(_) => block
-                    | B_Code(bcode) => {
-                        ...block,
-                        b_data: B_Code({...bcode, bc_widgets: widgets}),
-                      }
-                    };
-                  };
-                })
-              ),
-        })
+        Actions.addWidgets(action, state, blockId, widgets)
       | Block_FocusNextBlockOrCreate(blockTyp) =>
-        let blockLength = state.blocks->Belt.Array.length;
-
-        let currentBlockIndex =
-          switch (state.focusedBlock) {
-          | None => blockLength - 1
-          | Some((id, _blockTyp, _)) =>
-            switch (state.blocks->arrayFindIndex((({b_id}) => b_id == id))) {
-            | None => blockLength - 1
-            | Some(index) => index
-            }
-          };
-        let findBlockId = index => {
-          let {b_id, b_data} = state.blocks[index];
-          (b_id, blockDataToBlockTyp(b_data));
-        };
-        if (currentBlockIndex == blockLength - 1) {
-          ReasonReact.SideEffects(
-            (
-              ({send}) =>
-                send(
-                  Block_Add(findBlockId(currentBlockIndex)->fst, blockTyp),
-                )
-            ),
-          );
-        } else if (currentBlockIndex < blockLength - 1) {
-          let (nextBlockId, nextBlockTyp) =
-            findBlockId(currentBlockIndex + 1);
-          ReasonReact.Update({
-            ...state,
-            stateUpdateReason: Some(action),
-            focusedBlock:
-              Some((
-                nextBlockId,
-                nextBlockTyp,
-                FcTyp_BlockExecuteAndFocusNextBlock,
-              )),
-          });
-        } else {
-          ReasonReact.NoUpdate;
-        };
+        Actions.focusNextBlockOrCreate(action, state, blockTyp)
       | Block_Execute(focusNextBlock, blockTyp) =>
-        let allCodeToExecute = codeBlockDataPairs(state.blocks);
-
-        ReasonReact.SideEffects(
-          (
-            self => {
-              if (focusNextBlock) {
-                self.send(Block_FocusNextBlockOrCreate(blockTyp));
-              };
-              onExecute(true);
-              let id =
-                Toplevel_Consumer.execute(
-                  lang,
-                  allCodeToExecute,
-                  fun
-                  | Belt.Result.Error(error) => {
-                      onExecute(false);
-                      Notify.error(error);
-                    }
-                  | Belt.Result.Ok(blocks) => {
-                      onExecute(false);
-                      blocks
-                      ->(
-                          Belt.List.forEachU(
-                            (. {Toplevel.Types.id: blockId, result}) => {
-                            let widgets = executeResultToWidget(result);
-                            self.send(Block_AddWidgets(blockId, widgets));
-                          })
-                        );
-                    },
-                );
-
-              self.onUnmount(() => Toplevel_Consumer.cancel(id));
-            }
-          ),
-        );
+        Actions.execute(
+          action,
+          state,
+          focusNextBlock,
+          blockTyp,
+          onExecute,
+          lang,
+        )
       | Block_UpdateValue(blockId, newValue, diff) =>
-        let blockIndex = state.blocks->getBlockIndex(blockId);
-        ReasonReact.Update({
-          ...state,
-          stateUpdateReason: Some(action),
-          blocks:
-            state.blocks
-            ->(
-                Belt.Array.mapWithIndexU((. i, block) => {
-                  let {b_data} = block;
-                  if (i < blockIndex) {
-                    block;
-                  } else if (i == blockIndex) {
-                    switch (b_data) {
-                    | B_Code(bcode) => {
-                        ...block,
-                        b_data:
-                          B_Code({
-                            ...bcode,
-                            bc_value: newValue,
-                            bc_widgets: {
-                              let removeWidgetBelowMe =
-                                diff->getFirstLineFromDiff;
-                              let currentWidgets = bcode.bc_widgets;
-                              currentWidgets
-                              ->(
-                                  Belt.Array.keepU((. {Widget.lw_line, _}) =>
-                                    lw_line < removeWidgetBelowMe
-                                  )
-                                );
-                            },
-                          }),
-                      }
-                    | B_Text(_) => {...block, b_data: B_Text(newValue)}
-                    };
-                  } else {
-                    switch (b_data) {
-                    | B_Text(_) => block
-                    | B_Code(bcode) => {
-                        ...block,
-                        b_data: B_Code({...bcode, bc_widgets: [||]}),
-                      }
-                    };
-                  };
-                })
-              )
-            ->syncLineNumber,
-        });
+        Actions.update(action, state, blockId, newValue, diff)
       | Block_QueueDelete(blockId) =>
-        let queueTimeout = self => {
-          let timeoutId =
-            Js.Global.setTimeout(
-              () => self.ReasonReact.send(Block_DeleteQueued(blockId)),
-              10000,
-            );
-          self.onUnmount(() => Js.Global.clearTimeout(timeoutId));
-          self.ReasonReact.send(Block_CaptureQueuedMeta(blockId, timeoutId));
-        };
-        if (isLastBlock(state.blocks)) {
-          switch (isEmpty(state.blocks[0].b_data)) {
-          | true => ReasonReact.NoUpdate
-          | _ =>
-            ReasonReact.UpdateWithSideEffects(
-              {
-                ...state,
-                blocks:
-                  [|newBlock, {...state.blocks[0], b_deleted: true}|]
-                  ->syncLineNumber,
-                stateUpdateReason: Some(action),
-                focusedBlock: None,
-              },
-              (self => queueTimeout(self)),
-            )
-          };
-        } else {
-          ReasonReact.UpdateWithSideEffects(
-            {
-              ...state,
-              blocks:
-                state.blocks
-                ->(
-                    Belt.Array.mapU((. block) => {
-                      let {b_id} = block;
-                      b_id == blockId ? {...block, b_deleted: true} : block;
-                    })
-                  )
-                ->syncLineNumber,
-              stateUpdateReason: Some(action),
-              focusedBlock:
-                switch (state.focusedBlock) {
-                | None => None
-                | Some((focusedBlock, _, _)) =>
-                  focusedBlock == blockId ? None : state.focusedBlock
-                },
-            },
-            (self => queueTimeout(self)),
-          );
-        };
+        Actions.queueDelete(action, state, blockId)
       | Block_DeleteQueued(blockId) =>
-        if (isLastBlock(state.blocks) || Belt.Array.length(state.blocks) == 0) {
-          ReasonReact.Update({
-            ...state,
-            blocks: [|newBlock|],
-            deletedBlockMeta:
-              state.deletedBlockMeta
-              ->(
-                  Belt.Array.keepU((. (timeoutBlockId, _timeoutId)) =>
-                    timeoutBlockId != blockId
-                  )
-                ),
-            stateUpdateReason: Some(action),
-            focusedBlock: None,
-          });
-        } else {
-          ReasonReact.Update({
-            ...state,
-            blocks:
-              state.blocks
-              ->(Belt.Array.keepU((. {b_id}) => b_id != blockId))
-              ->syncLineNumber,
-            deletedBlockMeta:
-              state.deletedBlockMeta
-              ->(
-                  Belt.Array.keepU((. (timeoutBlockId, _timeoutId)) =>
-                    timeoutBlockId != blockId
-                  )
-                ),
-            stateUpdateReason: Some(action),
-            focusedBlock:
-              switch (state.focusedBlock) {
-              | None => None
-              | Some((focusedBlock, _, _)) =>
-                focusedBlock == blockId ? None : state.focusedBlock
-              },
-          });
-        }
-      | Block_Restore(blockId) =>
-        let timeoutId =
-          state.deletedBlockMeta
-          ->arrayFind(
-              (((timeBlockId, _timeoutId)) => timeBlockId == blockId),
-            );
-        switch (timeoutId) {
-        | None => ReasonReact.NoUpdate
-        | Some((_timeoutBlockId, timeoutId)) =>
-          ReasonReact.UpdateWithSideEffects(
-            {
-              ...state,
-              blocks:
-                state.blocks
-                ->(
-                    Belt.Array.mapU((. block) => {
-                      let {b_id} = block;
-
-                      b_id == blockId ? {...block, b_deleted: false} : block;
-                    })
-                  )
-                ->syncLineNumber,
-              deletedBlockMeta:
-                state.deletedBlockMeta
-                ->(
-                    Belt.Array.keepU((. (timeBlockId, _timeoutId)) =>
-                      timeBlockId != blockId
-                    )
-                  ),
-              stateUpdateReason: Some(action),
-            },
-            (_self => Js.Global.clearTimeout(timeoutId)),
-          )
-        };
+        Actions.deleteQueued(action, state, blockId)
+      | Block_Restore(blockId) => Actions.restore(action, state, blockId)
       | Block_CaptureQueuedMeta(blockId, timeoutId) =>
-        ReasonReact.Update({
-          ...state,
-          deletedBlockMeta:
-            Belt.Array.concat(
-              state.deletedBlockMeta,
-              [|(blockId, timeoutId)|],
-            ),
-          stateUpdateReason: Some(action),
-        })
+        Actions.captureQueuedMeta(action, state, blockId, timeoutId)
       | Block_Focus(blockId, blockTyp) =>
-        ReasonReact.Update({
-          ...state,
-          stateUpdateReason: Some(action),
-          focusedBlock: Some((blockId, blockTyp, FcTyp_EditorFocus)),
-        })
-      | Block_Blur(blockId) =>
-        switch (state.focusedBlock) {
-        | None => ReasonReact.NoUpdate
-        | Some((focusedBlockId, _, _)) =>
-          focusedBlockId == blockId ?
-            ReasonReact.Update({
-              ...state,
-              stateUpdateReason: Some(action),
-              focusedBlock: None,
-            }) :
-            ReasonReact.NoUpdate
-        }
+        Actions.focus(action, state, blockId, blockTyp)
+      | Block_Blur(blockId) => Actions.blur(action, state, blockId)
       | Block_Add(afterBlockId, blockTyp) =>
         Actions.add(action, state, afterBlockId, blockTyp)
       | Block_FocusUp(blockId) => Actions.focusUp(action, state, blockId)

--- a/client/src_editor/Editor_Blocks.rei
+++ b/client/src_editor/Editor_Blocks.rei
@@ -1,0 +1,42 @@
+open Editor_Types;
+
+type action =
+  | Block_Add(id, Block.blockTyp)
+  | Block_Execute(bool, Block.blockTyp)
+  | Block_FocusNextBlockOrCreate(Block.blockTyp)
+  | Block_QueueDelete(id)
+  | Block_DeleteQueued(id)
+  | Block_CaptureQueuedMeta(id, Js.Global.timeoutId)
+  | Block_Restore(id)
+  | Block_Focus(id, Block.blockTyp)
+  | Block_Blur(id)
+  | Block_UpdateValue(id, string, CodeMirror.EditorChange.t)
+  | Block_AddWidgets(id, array(Widget.t))
+  | Block_FocusUp(id)
+  | Block_FocusDown(id)
+  | Block_ChangeLanguage
+  | Block_PrettyPrint
+  | Block_CleanBlocksCopy
+  | Block_MapRefmtToBlocks(list((id, string)));
+
+type state = {
+  lang,
+  blocks: array(Block.block),
+  blocksCopy: option(array(Block.block)),
+  deletedBlockMeta: array((id, Js.Global.timeoutId)),
+  stateUpdateReason: option(action),
+  focusedBlock: option((id, Block.blockTyp, Block.focusChangeType)),
+};
+
+let make:
+  (
+    ~lang: lang=?,
+    ~blocks: array(Block.block),
+    ~readOnly: bool=?,
+    ~onUpdate: array(Block.block) => unit,
+    ~onExecute: bool => 'a,
+    ~registerExecuteCallback: (unit => unit) => unit=?,
+    ~registerShortcut: Shortcut.subscribeFun=?,
+    React.childless
+  ) =>
+  ReasonReact.component(state, ReasonReact.noRetainedProps, action);

--- a/client/src_editor/Editor_Blocks.rei
+++ b/client/src_editor/Editor_Blocks.rei
@@ -6,7 +6,6 @@ type action =
   | Block_FocusNextBlockOrCreate(Block.blockTyp)
   | Block_QueueDelete(id)
   | Block_DeleteQueued(id)
-  | Block_CaptureQueuedMeta(id, Js.Global.timeoutId)
   | Block_Restore(id)
   | Block_Focus(id, Block.blockTyp)
   | Block_Blur(id)
@@ -19,11 +18,13 @@ type action =
   | Block_CleanBlocksCopy
   | Block_MapRefmtToBlocks(list((id, string)));
 
+module TimeoutMap = Belt.Map.String;
+
 type state = {
   lang,
   blocks: array(Block.block),
   blocksCopy: option(array(Block.block)),
-  deletedBlockMeta: array((id, Js.Global.timeoutId)),
+  deletedBlockMeta: ref(TimeoutMap.t(Js.Global.timeoutId)),
   stateUpdateReason: option(action),
   focusedBlock: option((id, Block.blockTyp, Block.focusChangeType)),
 };

--- a/client/src_editor/Editor_Blocks_Utils.re
+++ b/client/src_editor/Editor_Blocks_Utils.re
@@ -5,7 +5,7 @@ let mapCode = (blocks: array(Block.block), cb) =>
       (. block) => {
         let {Block.b_id, b_deleted, b_data} = block;
         switch (b_data) {
-        | B_Code(data) => cb(~block, ~id=b_id, ~deleted=b_deleted, ~data)
+        | B_Code(bcode) => cb(~block, ~id=b_id, ~deleted=b_deleted, ~bcode)
         | B_Text(_) => block
         };
       },

--- a/client/src_editor/Editor_Blocks_Utils.re
+++ b/client/src_editor/Editor_Blocks_Utils.re
@@ -28,7 +28,6 @@ let renderErrorIndicator = (colStart, colEnd, content) =>
 
 let executeResultToWidget = (result: list(Worker_Types.blockData)) => {
   open Worker_Types;
-  open Editor_Types;
   let clampLineNumber = line => max(0, line);
 
   let widgets =

--- a/client/src_editor/Editor_Blocks_Utils.re
+++ b/client/src_editor/Editor_Blocks_Utils.re
@@ -1,3 +1,15 @@
+open Editor_Types;
+let mapCode = (blocks: array(Block.block), cb) =>
+  blocks
+  ->Belt.Array.mapU(
+      (. block) => {
+        let {Block.b_id, b_deleted, b_data} = block;
+        switch (b_data) {
+        | B_Code(data) => cb(~block, ~id=b_id, ~deleted=b_deleted, ~data)
+        | B_Text(_) => block
+        };
+      },
+    );
 /*
  * Block Execution Utils
  */

--- a/client/src_editor/Editor_Blocks_Utils.re
+++ b/client/src_editor/Editor_Blocks_Utils.re
@@ -138,7 +138,7 @@ let syncLineNumber: array(block) => array(block) =
           },
         )
       )
-    ->Utils.pluckAcc;
+    ->fst;
 
 let getFirstLineFromDiff = (diff: CodeMirror.EditorChange.t) => {
   let fromPos = diff->CodeMirror.EditorChange.fromGet;
@@ -196,26 +196,7 @@ let findLastCodeBlock = blocks => {
 };
 
 /*
- * Block Refmt Utils
- */
-
-/* let getBlockRefmtResult = (results, blockId) => {
-     let result =
-       results
-       |> List.find(data => {
-            let (id, code) = data;
-            id == blockId;
-          });
-     let (_b_id, bc_value, hasError) = result;
-     switch (hasError) {
-     | None => ()
-     | Some(error) => notifyRefmtError(bc_value, error, lang)
-     };
-     bc_value;
-   }; */
-
-/*
- * Ohter Block Utils
+ * Other Block Utils
  */
 
 let codeBlockDataPairs = blocks =>

--- a/client/src_editor/Editor_Blocks_Utils.re
+++ b/client/src_editor/Editor_Blocks_Utils.re
@@ -167,12 +167,6 @@ let emptyCodeBlock = () =>
 
 let emptyTextBlock = () => B_Text("");
 
-let newBlock = {
-  b_id: Utils.generateId(),
-  b_data: emptyCodeBlock(),
-  b_deleted: false,
-};
-
 let isEmpty =
   fun
   | B_Code({bc_value}) => String.length(bc_value) == 0

--- a/client/src_editor/Editor_Note.re
+++ b/client/src_editor/Editor_Note.re
@@ -127,7 +127,7 @@ module Editor_Note = {
           | (Ec_Dirty, SaveStatus_Done({lastEdited: _})) =>
             ReasonReact.Update({...state, editorContentStatus: Ec_Dirty})
           | (_, SaveStatus_Done({lastEdited})) =>
-            Notify.info("Saved successfully", ~sticky=false);
+            Notify.success("Saved successfully", ~sticky=false);
             ReasonReact.UpdateWithSideEffects(
               {
                 ...state,
@@ -149,7 +149,7 @@ module Editor_Note = {
         | UpdateForkStatus(forkStatus) =>
           switch (forkStatus) {
           | ForkStatus_Done({newId, forkFrom, lastEdited, owner}) =>
-            Notify.info("Forked successfully", ~sticky=false);
+            Notify.success("Forked successfully", ~sticky=false);
             ReasonReact.UpdateWithSideEffects(
               {
                 ...state,

--- a/client/src_editor/Editor_Types.re
+++ b/client/src_editor/Editor_Types.re
@@ -84,12 +84,6 @@ module Block = {
     b_deleted: bool,
   };
 
-  type deletedBlockMeta = {
-    db_id: id,
-    db_data: blockData,
-    to_id: Js.Global.timeoutId,
-  };
-
   type focusChangeType =
     | FcTyp_EditorFocus
     | FcTyp_BlockNew


### PR DESCRIPTION
I'm moving each reducer handler into it own function. There are no performance hits because Bucklescript inlines the functions body directly to reducer sections when you add an interface and hide the functions

I also added a tons of comments on each functions. 

cc @matthiaskern @no-stack-dub-sack 