### PR TITLE
Refactor prevent route transition

### DIFF
--- a/client/src/Router.re
+++ b/client/src/Router.re
@@ -10,16 +10,14 @@ module Unload = {
   type callback = option(message => unit);
   let cb: ref(callback) = ref(None);
 
-  let unregister = () => {
-    cb := None;
-    message := None;
+  let register = (callback: message => unit) => {
+    cb := Some(callback);
     ();
   };
 
-  let setMessage = content => message := content;
-
-  let register = (callback: message => unit) => {
-    cb := Some(callback);
+  let unregister = () => {
+    cb := None;
+    message := None;
     ();
   };
 

--- a/client/src/Router.rei
+++ b/client/src/Router.rei
@@ -1,3 +1,15 @@
+/*
+ * Unload
+ * This is a helper to prevent route transition
+ * when there is unsaved content
+ * Example:
+ *  let derivedMessageFromState: state => option(string) =
+ *  let unloadHandler = (message, self) => {
+ *    message := derivedMessageFromState(self.ReasonReact.state)
+ *    ();
+ *  };
+ *  Router.Unload.register(self.handle(unloadHandler));
+ */
 module Unload: {
   type message = ref(option(string));
   type callback = option(message => unit);
@@ -5,16 +17,18 @@ module Unload: {
   let register: (message => unit) => unit;
   let unregister: unit => unit;
 
+  /*
+   * Provider
+   * Put this in any component
+   */
   module Provider: {
     let make:
-      React.childless =>
-      React.component(unit, ReasonReact.noRetainedProps, unit);
+      React.childless => React.component(unit, React.noRetainedProps, unit);
   };
 };
 
 let redirect: string => unit;
 let push: Route.t => unit;
-
 let pushSilent: Route.t => unit;
 let replaceSilent: Route.t => unit;
 
@@ -27,11 +41,7 @@ module Link: {
       ~className: string=?,
       ~popup: bool=?,
       ~role: string=?,
-      array(ReasonReact.reactElement)
+      array(React.reactElement)
     ) =>
-    ReasonReact.component(
-      ReasonReact.stateless,
-      ReasonReact.noRetainedProps,
-      ReasonReact.actionless,
-    );
+    React.component(React.stateless, React.noRetainedProps, React.actionless);
 };

--- a/client/src/Router.rei
+++ b/client/src/Router.rei
@@ -1,0 +1,37 @@
+module Unload: {
+  type message = ref(option(string));
+  type callback = option(message => unit);
+
+  let register: (message => unit) => unit;
+  let unregister: unit => unit;
+
+  module Provider: {
+    let make:
+      React.childless =>
+      React.component(unit, ReasonReact.noRetainedProps, unit);
+  };
+};
+
+let redirect: string => unit;
+let push: Route.t => unit;
+
+let pushSilent: Route.t => unit;
+let replaceSilent: Route.t => unit;
+
+module Link: {
+  let make:
+    (
+      ~route: Route.t,
+      ~id: string=?,
+      ~title: string=?,
+      ~className: string=?,
+      ~popup: bool=?,
+      ~role: string=?,
+      array(ReasonReact.reactElement)
+    ) =>
+    ReasonReact.component(
+      ReasonReact.stateless,
+      ReasonReact.noRetainedProps,
+      ReasonReact.actionless,
+    );
+};

--- a/client/src_editor/Editor_Note.re
+++ b/client/src_editor/Editor_Note.re
@@ -79,20 +79,18 @@ module Editor_Note = {
           };
         },
       didMount: self => {
-        let derivedMessageFromStatus =
-          fun
-          | Ec_Saved
-          | Ec_Pristine => None
-          | _ => Some("Changes you made may not be saved");
-        let unloadHandler: (ref(option(string)), unit) => unit =
-          (message, ()) => {
-            message :=
-              derivedMessageFromStatus(
-                self.ReasonReact.state.editorContentStatus,
-              );
-            ();
-          };
-        Router.Unload.register(unloadHandler);
+        let unloadHandler = (message, self) => {
+          message :=
+            (
+              switch (self.ReasonReact.state.editorContentStatus) {
+              | Ec_Saved
+              | Ec_Pristine => None
+              | _ => Some("Changes you made may not be saved")
+              }
+            );
+          ();
+        };
+        Router.Unload.register(self.handle(unloadHandler));
         self.onUnmount(Router.Unload.unregister);
       },
       reducer: (action, state) =>

--- a/client/src_editor/Editor_Note.re
+++ b/client/src_editor/Editor_Note.re
@@ -73,19 +73,28 @@ module Editor_Note = {
       didUpdate: ({oldSelf, newSelf}) =>
         if (newSelf.state.editorContentStatus
             != oldSelf.state.editorContentStatus) {
-          let unloadMessage =
-            switch (newSelf.state.editorContentStatus) {
-            | Ec_Saved
-            | Ec_Pristine => None
-            | _ => Some("Changes you made may not be saved")
-            };
-          Router.Unload.register(unloadMessage);
           /* This execute the code after save */
           if (newSelf.state.editorContentStatus == Ec_Saved) {
             newSelf.send(Execute);
           };
         },
-      didMount: ({onUnmount}) => onUnmount(Router.Unload.unregister),
+      didMount: self => {
+        let derivedMessageFromStatus =
+          fun
+          | Ec_Saved
+          | Ec_Pristine => None
+          | _ => Some("Changes you made may not be saved");
+        let unloadHandler: (ref(option(string)), unit) => unit =
+          (message, ()) => {
+            message :=
+              derivedMessageFromStatus(
+                self.ReasonReact.state.editorContentStatus,
+              );
+            ();
+          };
+        Router.Unload.register(unloadHandler);
+        self.onUnmount(Router.Unload.unregister);
+      },
       reducer: (action, state) =>
         switch (action) {
         | TitleUpdate(title) =>


### PR DESCRIPTION
Switch from updating the message on each state update from callback based solution. Only get the message when needed

This is the original implementation in #77 but I couldn't figure out the API at the time. 