### PR TITLE
refactor: Use key instead of willReceiveProps

### DIFF
--- a/client/src/Note.re
+++ b/client/src/Note.re
@@ -54,6 +54,7 @@ let make = (~noteInfo: Route.noteRouteConfig, _children: React.childless) => {
                                   };
                                 <RedirectSketchURL noteId>
                                   ...<Editor_Note
+                                       key=noteId
                                        noteOwnerId=note##user_id
                                        noteLastEdited=(Some(note##updated_at))
                                        noteId

--- a/client/src/NoteNew.re
+++ b/client/src/NoteNew.re
@@ -21,11 +21,13 @@ let make = (~blocks=defaultBlocks, ~title=?, ~lang, _children) => {
                | Anonymous => Config.anonymousUserId
                | Login(userId) => userId
                };
+             let noteId = Utils.generateId();
              <Editor_Note
+               key=noteId
                hasSavePermission=true
                noteOwnerId=userId
                noteLastEdited=None
-               noteId=(Utils.generateId())
+               noteId
                noteState=NoteState_New
                blocks
                lang

--- a/client/src_editor/Editor_Note.re
+++ b/client/src_editor/Editor_Note.re
@@ -64,12 +64,6 @@ module Editor_Note = {
     {
       ...component,
       initialState: makeInitialState,
-      willReceiveProps: self =>
-        if (self.state.noteId != initialNoteId) {
-          makeInitialState();
-        } else {
-          self.state;
-        },
       didUpdate: ({oldSelf, newSelf}) =>
         if (newSelf.state.editorContentStatus
             != oldSelf.state.editorContentStatus) {


### PR DESCRIPTION
Turn out key has special power in React (rather than just used in array). By using key, React will ensure that it unmount old editor and mounting a fresh one.

More information from React's docs: https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html