### PR TITLE
refactor: Get blocks information on demand

### DIFF
--- a/client/shared/Utils.re
+++ b/client/shared/Utils.re
@@ -22,6 +22,17 @@ let arrayFirst = (array, ~empty, ~render) =>
     warn2("This array contains more than 1 element", array);
     render(array[0]);
   };
+let handleWithReturn = (self, fn, thing) => {
+  let return = ref(None);
+  self.ReasonReact.handle(
+    (thing, self) => return := Some(fn(self, thing)),
+    thing,
+  );
+  switch (return^) {
+  | Some(return) => return
+  | None => failwith("handleWithReturn failed to get a valid return value")
+  };
+};
 
 /*
  Tap log: Log and return the value

--- a/client/src_editor/Editor_Blocks.re
+++ b/client/src_editor/Editor_Blocks.re
@@ -603,6 +603,7 @@ let make =
       ~onUpdate,
       ~onExecute,
       ~registerExecuteCallback=?,
+      ~registerGetBlocksCallback,
       ~registerShortcut: option(Shortcut.subscribeFun)=?,
       _children: React.childless,
     ) => {
@@ -625,6 +626,9 @@ let make =
       },
     didMount: self => {
       self.send(Block_Execute(false, BTyp_Code));
+      registerGetBlocksCallback(
+        handleWithReturn(self, (self, ()) => self.ReasonReact.state.blocks),
+      );
       switch (registerExecuteCallback) {
       | None => ()
       | Some(register) =>
@@ -713,7 +717,7 @@ let make =
           | Block_Add(_, _)
           | Block_DeleteQueued(_)
           | Block_Restore(_)
-          | Block_UpdateValue(_, _, _) => onUpdate(newSelf.state.blocks)
+          | Block_UpdateValue(_, _, _) => onUpdate()
           };
 
           switch (action) {

--- a/client/src_editor/Editor_Blocks.rei
+++ b/client/src_editor/Editor_Blocks.rei
@@ -34,9 +34,10 @@ let make:
     ~lang: lang=?,
     ~blocks: array(Block.block),
     ~readOnly: bool=?,
-    ~onUpdate: array(Block.block) => unit,
+    ~onUpdate: unit => unit,
     ~onExecute: bool => 'a,
     ~registerExecuteCallback: (unit => unit) => unit=?,
+    ~registerGetBlocksCallback: (unit => array(Block.block)) => unit,
     ~registerShortcut: Shortcut.subscribeFun=?,
     React.childless
   ) =>


### PR DESCRIPTION
We don't need to merge Editor_Blocks and Editor_Note together anymore. Yikes ! 

Explaining this PR:

# Before

Editor_Note keeps a copy of blocks in its state (via instance variables) and Editor_Blocks would call a callback on every update to update `Editor_Note.state.blocks`
This is error-prone and potentially lost user data if we don't call the callback when making the changes. 

The ideal solution would managing `blocks` data inside `Editor_Note`. But the `Editor_Blocks` is about 1000 lines, `Editor_Note` is about 400 lines. Imaging merging them together and trying to work on them. 

# After

Instead of `Editor_Blocks` calling the callback on update, `Editor_Note` would pass a callback to get up-to-date `blocks` data directly from `Editor_Blocks` when it needs to access it. This is pretty straight forwards. 
`onUpdate` callback is still there, but it's not mission critical anymore, it's used to notify `Editor_Note` and set `Ec_Dirty` to prevent losing content. After implementing #159 , we can remove it completely :100: 

cc @matthiaskern 

--- 

Sidenote: I'm seriously considering about a global store solution to avoid all of this. redux solves this problem nicely and have out-of-the-box global undo. :( 