### PR TITLE
feat: Responsive improvements 

### DIFF
--- a/client/src/components/UI_SketchList.css
+++ b/client/src/components/UI_SketchList.css
@@ -13,19 +13,14 @@
   text-decoration: none;
   color: var(--c-primary);
   font-size: var(--f4);
-
-  &:hover .UI_SketchList__sketch--title {
-    color: var(--c-text);
-  }
 }
 
 .UI_SketchList__sketch--title {
   font-weight: 500;
   color: var(--c-text-sub);
-}
-
-.UI_SketchList__sketch--dash {
-  color: var(--c-text);
+  &:hover {
+    color: var(--c-text);
+  }
 }
 
 .UI_SketchList__sketch--lastEdited {

--- a/client/src/components/UI_SketchList.re
+++ b/client/src/components/UI_SketchList.re
@@ -27,10 +27,6 @@ let make =
                          }
                        )
                      </span>
-                     <span className="UI_SketchList__sketch--dash">
-                       " - "->str
-                     </span>
-                     ("/s/" ++ sketch##id)->str
                    </Router.Link>
                    <div className="UI_SketchList__sketch--lastEdited">
                      "last edited"->str

--- a/client/src/components/UI_Topbar.css
+++ b/client/src/components/UI_Topbar.css
@@ -45,6 +45,12 @@
   &:visited {
     color: var(--c-primary);
   }
+  & > span {
+    display: none;
+    @media (--md) {
+      display: inline;
+    }
+  }
 }
 
 .Topbar__action {
@@ -66,9 +72,28 @@
   display: flex;
   justify-content: center;
   align-content: center;
-  padding: 0 var(--space3);
   outline: none;
   color: var(--c-text-sub);
+  padding: 0 var(--space3);
+
+  & > span {
+    display: none;
+  }
+
+  & > svg {
+    height: 1.5rem;
+    width: 1.5rem;
+  }
+
+  @media (--md) {
+    & > svg {
+      height: 1rem;
+      width: 1rem;
+    }
+    & > span {
+      display: inline;
+    }
+  }
 }
 
 .Topbar__action:hover {

--- a/client/src/components/UI_Topbar.re
+++ b/client/src/components/UI_Topbar.re
@@ -22,7 +22,7 @@ let make = _children => {
         <Router.Link
           route=Route.Home className="Topbar__home" title="Sketch.sh Homepage">
           <Logo size=0.2 />
-          "Sketch.sh"->str
+          <span> "Sketch.sh"->str </span>
         </Router.Link>
         <div id className="Topbar__actions" />
       </div>

--- a/client/src/components/UI_TopbarUserInfo.css
+++ b/client/src/components/UI_TopbarUserInfo.css
@@ -7,10 +7,13 @@
 }
 
 .Topbar__userInfo--content {
-  margin-right: var(--space2);
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
+  display: none;
+  @media (--md) {
+    display: flex;
+    margin-right: var(--space2);
+    flex-direction: column;
+    align-items: flex-end;
+  }
 }
 
 .Topbar__userInfo--name,

--- a/client/src_editor/Editor_Blocks.css
+++ b/client/src_editor/Editor_Blocks.css
@@ -1,135 +1,136 @@
 .block__container {
-	margin-top: var(--space4);
-	padding: 0px;
-	position: relative;
+  margin-top: var(--space4);
+  padding: 0;
+  /* Codemirror adds an overflow textarea that can't be get rid of */
+  overflow: hidden;
 }
 
 .block__controls {
-	margin-top: var(--space1);
-	margin-left: calc(var(--cm-gutter-width));
-	display: flex;
-	flex-direction: row-reverse;
+  margin-top: var(--space1);
+  margin-left: calc(var(--cm-gutter-width));
+  display: flex;
+  flex-direction: row-reverse;
 }
 
 .block__controls--buttons {
-	display: flex;
+  display: flex;
 }
 
 .block__controls--button {
-	background: none;
-	border: 0;
-	outline: none;
-	font-weight: 700;
-	padding: 0;
-	color: #aaa;
-	transition: color 250ms ease;
-	margin-right: var(--space3);
-	cursor: pointer;
-	font-size: var(--f5);
+  background: none;
+  border: 0;
+  outline: none;
+  font-weight: 700;
+  padding: 0;
+  color: #aaa;
+  transition: color 250ms ease;
+  margin-right: var(--space3);
+  cursor: pointer;
+  font-size: var(--f5);
 
-	& svg {
-		margin-right: var(--space1);
-	}
+  & svg {
+    margin-right: var(--space1);
+  }
 
-	&:hover {
-		color: var(--c-primary) !important;
-	}
+  &:hover {
+    color: var(--c-primary) !important;
+  }
 
-	&.block__controls--danger:hover {
-		color: var(--c-danger) !important;
-	}
+  &.block__controls--danger:hover {
+    color: var(--c-danger) !important;
+  }
 }
 
 .block__container:hover .block__controls--button {
-	color: #888;
+  color: #888;
 }
 
 .block__controls--button:last-of-type {
-	margin-right: 0;
+  margin-right: 0;
 }
 
 /* ////////// Deleted block //////////////// */
 .block__deleted {
-	margin-left: var(--cm-gutter-width);
-	border-radius: 4px;
-	padding: var(--space4);
-	background: hsl(220, 80%, 95%);
-	text-align: center;
-	font-size: var(--f4);
-	position: relative;
+  margin-left: var(--cm-gutter-width);
+  border-radius: 4px;
+  padding: var(--space4);
+  background: hsl(220, 80%, 95%);
+  text-align: center;
+  font-size: var(--f4);
+  position: relative;
 }
 
 .block__deleted h3 {
-	margin: var(--space2) 0;
+  margin: var(--space2) 0;
 }
 
 .block__deleted p {
-	margin: 0;
+  margin: 0;
 }
 
 .block__deleted--progress {
-	width: 0;
-	position: absolute;
-	background: var(--c-primary);
-	right: 0;
-	bottom: 0;
-	left: 0;
-	height: 5px;
-	animation: width 10s linear forwards;
-	opacity: 1;
-	z-index: 1;
+  width: 0;
+  position: absolute;
+  background: var(--c-primary);
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: 5px;
+  animation: width 10s linear forwards;
+  opacity: 1;
+  z-index: 1;
 }
 
 @keyframes width {
-	0% {
-		width: 100%;
-	}
+  0% {
+    width: 100%;
+  }
 
-	100% {
-		width: 0;
-	}
+  100% {
+    width: 0;
+  }
 }
 
 .block__deleted--active {
-	width: 0;
-	opacity: 1;
+  width: 0;
+  opacity: 1;
 }
 
 .block__deleted--buttons {
-	display: flex;
-	justify-content: center;
-	margin-top: var(--space3);
+  display: flex;
+  justify-content: center;
+  margin-top: var(--space3);
 }
 
 .block__deleted--button {
-	z-index: 2;
-	outline: none;
-	display: flex;
-	padding: var(--space3);
-	margin: 0 5px;
-	border: 0;
-	border-radius: 4px;
-	transition: background-color 100ms ease-in-out;
-	font-size: var(--f4);
-	cursor: pointer;
+  z-index: 2;
+  outline: none;
+  display: flex;
+  padding: var(--space3);
+  margin: 0 5px;
+  border: 0;
+  border-radius: 4px;
+  transition: background-color 100ms ease-in-out;
+  font-size: var(--f4);
+  cursor: pointer;
 
-	& svg {
-		margin-right: var(--space2);
-	}
+  & svg {
+    margin-right: var(--space2);
+  }
 }
 
 .block__deleted--button.restore {
-	background-color: color-mod(#1874d5 a(0.2));
+  background-color: color-mod(#1874d5 a(0.2));
 }
 
 .block__deleted--button.restore:hover {
-	background-color: color-mod(#1874d5 a(0.3));
+  background-color: color-mod(#1874d5 a(0.3));
 }
 
 .block__deleted--button.delete-immediately {
-	background-color: color-mod(#da4139 a(0.2));
+  background-color: color-mod(#da4139 a(0.2));
 }
 
 .block__deleted--button.delete-immediately:hover {
-	background-color: color-mod(#da4139 a(0.3));
+  background-color: color-mod(#da4139 a(0.3));
 }

--- a/client/src_editor/Editor_Blocks.css
+++ b/client/src_editor/Editor_Blocks.css
@@ -51,7 +51,6 @@
 
 /* ////////// Deleted block //////////////// */
 .block__deleted {
-  margin-left: var(--cm-gutter-width);
   border-radius: 4px;
   padding: var(--space4);
   background: hsl(220, 80%, 95%);

--- a/client/src_editor/Editor_Note.css
+++ b/client/src_editor/Editor_Note.css
@@ -1,10 +1,10 @@
 .EditorNote {
-	min-width: 768px;
+	/* min-width: 768px; */
 }
 
-.EditorNote__metadata {
+/* .EditorNote__metadata {
 	margin-left: calc(var(--cm-gutter-width) + 8px);
-}
+} */
 
 .EditorNote__metadata--title {
 	width: 100%;

--- a/client/src_editor/Editor_Note.re
+++ b/client/src_editor/Editor_Note.re
@@ -204,7 +204,7 @@ module Editor_Note = {
                                        <Fi.Play />
                                  )
                             </UI_LoadingWrapper>
-                            "Run"->str
+                            <span> "Run"->str </span>
                           </button>
                      </UI_Balloon>
                      <Editor_Note_SaveButton

--- a/client/src_editor/Editor_Note_ForkButton.re
+++ b/client/src_editor/Editor_Note_ForkButton.re
@@ -45,7 +45,7 @@ module ForkButton = {
                         <Fi.GitBranch />
                   )
              </UI_LoadingWrapper>
-             "Fork"->str
+             <span> "Fork"->str </span>
            </button>
       </UI_Balloon>,
   };

--- a/client/src_editor/Editor_Note_SaveButton.re
+++ b/client/src_editor/Editor_Note_SaveButton.re
@@ -75,7 +75,7 @@ module SaveButton = {
                         <Fi.Save />
                   )
              </UI_LoadingWrapper>
-             "Save"->str
+             <span> "Save"->str </span>
            </button>
       </UI_Balloon>,
   };

--- a/client/src_editor/cm-theme.css
+++ b/client/src_editor/cm-theme.css
@@ -155,7 +155,10 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {
 .source-editor .CodeMirror {
   height: auto !important;
 }
+.source-editor .CodeMirror {
+  border: 1px solid #aaa;
+}
 
 .text-editor {
-  margin-left: var(--cm-gutter-width);
+  margin-left: -8px;
 }


### PR DESCRIPTION
Add border for code blocks 

![image](https://user-images.githubusercontent.com/3049054/45104565-92a20780-b15c-11e8-8f0a-19e3e0b5be09.png)

Make topbar responsive on mobile

![image](https://user-images.githubusercontent.com/3049054/45104602-a64d6e00-b15c-11e8-9e8c-6f8f8551a658.png)

Editor_Note is now fully responsive

![rtop-mepvyifhuq now sh_ iphone 6_7_8](https://user-images.githubusercontent.com/3049054/45104665-cbda7780-b15c-11e8-84c8-c7b7c591a8ee.png)

