### PR TITLE
fix(bs): fix protocol regexp so it understands polestar-anonymous://

### DIFF
--- a/client/src/container/Container_bundler.re
+++ b/client/src/container/Container_bundler.re
@@ -102,7 +102,7 @@ module Sketch_polestar = {
   // => ("npm:", "uuid@latest")
 
   let get_protocol_pathname = url => {
-    Js.String.match([%re "/(^[a-zA-Z]+\\:)(?:\\/.)(.+)/"], url)
+    Js.String.match([%re "/(^[a-zA-Z\-]+\\:)(?:\\/.)(.+)/"], url)
     ->Belt.Option.flatMap(matches =>
         switch (matches->Belt.Array.length) {
         | 3 => Some((matches[1], matches[2]))


### PR DESCRIPTION
To repro the original issue, go to beta.sketch.sh and paste:

```
[@bs.deriving jsConverter]
type t =
  | [@bs.as 1] Hint
  | [@bs.as 2] Info
  | [@bs.as 4] Warning
  | [@bs.as 8] Error;
let a = tToJs(Hint);
Js.log(a);
```

Nothing shows on the output and the console shows an error `uncaught exception: [Fetcher] Invalid url polestar-anonymous://stdlib/js_mapperRt.js`