### PR TITLE
feat(bs): Add Relude as an external package

### DIFF
--- a/engine_bs/packages/bsconfig.json
+++ b/engine_bs/packages/bsconfig.json
@@ -2,8 +2,8 @@
   "name": "packages",
   "version": "0.1.0",
   "sources": {
-    "dir" : "src",
-    "subdirs" : true
+    "dir": "src",
+    "subdirs": true
   },
   "package-specs": {
     "module": "commonjs",
@@ -11,10 +11,10 @@
   },
   "suffix": ".bs.js",
   "bs-dependencies": [
-
+    "relude"
   ],
   "warnings": {
-    "error" : "+101"
+    "error": "+101"
   },
   "namespace": true,
   "refmt": 3

--- a/engine_bs/packages/package.json
+++ b/engine_bs/packages/package.json
@@ -12,6 +12,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "bs-platform": "5.0.6"
+    "bs-platform": "5.0.6",
+    "relude": "^0.19.0"
   }
 }


### PR DESCRIPTION
This adds relude as an external package. I'm not too sure if I missed anything but I did double check the list in #244 to make sure that relude satisfies all requirements which it does.

Let me know if there's anything else I need to do.