### PR TITLE
Use postgres 13.5, update path for dev instruction

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -99,7 +99,7 @@ Server implementation contains 2 microservices: auth, hasura's graphql engine
 - Open `.env` and add `AUTH_GITHUB_CLIENT_ID` and `AUTH_GITHUB_CLIENT_SECRET`
 
 
-~/sketch-sh: > cd sever
+~/sketch-sh: > cd server
 
 
 - Start docker-compose in detach mode

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -93,10 +93,14 @@ Server implementation contains 2 microservices: auth, hasura's graphql engine
 - Copy `.env.example` to `.env`
 
 ```sh
-~/sketch-sh/server: > cp .env.example .env
+~/sketch-sh: > cp .env.example .env
 ```
 
 - Open `.env` and add `AUTH_GITHUB_CLIENT_ID` and `AUTH_GITHUB_CLIENT_SECRET`
+
+
+~/sketch-sh: > cd sever
+
 
 - Start docker-compose in detach mode
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.6'
 services:
   postgres:
-    image: postgres
+    image: postgres:13.5
     ports:
     - "5432:5432"
     environment:


### PR DESCRIPTION
Getting some error running composer up, which caused by:
```
 {"internal":"SCRAM authentication requires libpq version 10 or above\n","path":"$","error":"connection error","code":"postgres-error"}
 ```
- Set `postgres:13.5` in docker composer for quick first
- Update path for the developer instruction, the `.env` should be on the root instead of `/sever` folder