### PR TITLE
Fixed wrong docker-compose.dev.yml and add more notice.

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -79,7 +79,7 @@ Server implementation contains 2 microservices: auth, hasura's graphql engine
 
 - You need to have these installed
   - `docker`: Find installation instructions for your platform from [docker's docs](https://docs.docker.com/install/#supported-platforms).
-  - `docker-compose`: Head over to [docker-compose's release page](https://github.com/docker/compose/releases). Choose the latest release and follow the instruction.
+  - `docker-compose`: Head over to [docker-compose's release page](https://github.com/docker/compose/releases). Choose the latest release and follow the instruction. If you are a macOS user, head over to https://docs.docker.com/desktop/mac/install/ to install Docker with docker-compose inside. 
 
 - Github OAuth apps
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -3,6 +3,8 @@ services:
   graphql-engine:
     ports:
       - "8080:8080"
+    depends_on:
+      - postgres  
   auth:
     # you can use legacy debug config or new inspect
     # NOTE: if nodemon isn't restarting on changes, you might be on Windows
@@ -28,10 +30,6 @@ services:
       # this will overwrite the default node_modules dir in container so it won't conflict with our
       # /opt/node_modules location. Thanks to PR from @brnluiz
       - notused:/opt/app/node_modules
-  graphql-engine:
-    ports:
-      - "8080:8080"
-
   nginx:
     build:
       args:


### PR DESCRIPTION
Was removed duplicated rows for `graphql-engine:` in `docker-compose.dev.yml` file.
Was added some more text about docker-compose installation for macOS users.