### PR TITLE
Fix reformatting issue with CodeMirror.re

### DIFF
--- a/client/src_editor/CodeMirror.re
+++ b/client/src_editor/CodeMirror.re
@@ -103,7 +103,8 @@ module EditorConfiguration = {
     dragDrop: bool,
     /** When given , this will be called when the editor is handling a dragenter , dragover , or drop event.
         It will be passed the editor instance and the event object as arguments.
-        The callback can choose to handle the event itself , in which case it should return true to indicate that CodeMirror should not do anything further. */ /* TODO */ /* onDragEvent?: (instance: CodeMirror.Editor, event: Event) => boolean; *//** This provides a rather low - level hook into CodeMirror's key handling.
+        The callback can choose to handle the event itself , in which case it should return true to indicate that CodeMirror should not do anything further.
+        (* TODO *) onDragEvent?: (instance: CodeMirror.Editor, event: Event) => boolean; *//** This provides a rather low - level hook into CodeMirror's key handling.
         If provided, this function will be called on every keydown, keyup, and keypress event that CodeMirror captures.
         It will be passed two arguments, the editor instance and the key event.
         This key event is pretty much the raw key event, except that a stop() method is always added to it.
@@ -112,7 +113,9 @@ module EditorConfiguration = {
         It may return true to tell CodeMirror to ignore the event.
         Be wary that, on some browsers, stopping a keydown does not stop the keypress from firing, whereas on others it does.
         If you respond to an event, you should probably inspect its type property and only do something when it is keydown
-        (or keypress for actions that need character data). *//* TODO */ /* onKeyEvent?: (instance: CodeMirror.Editor, event: Event) => boolean; */ /** Half - period in milliseconds used for cursor blinking. The default blink rate is 530ms. */
+        (or keypress for actions that need character data).
+        (* TODO *) onKeyEvent?: (instance: CodeMirror.Editor, event: Event) => boolean;
+        Half - period in milliseconds used for cursor blinking. The default blink rate is 530ms. */
     [@bs.optional]
     cursorBlinkRate: int,
     /** Determines the height of the cursor. Default is 1 , meaning it spans the whole height of the line.
@@ -149,7 +152,9 @@ module EditorConfiguration = {
         and thus the browser's text search works on it. This will have bad effects on performance of big documents. */
     [@bs.optional]
     viewportMargin: float,
-    /** Optional lint configuration to be used in conjunction with CodeMirror's linter addon. *//* TODO */ /* lint?: boolean | LintOptions; */ /** Optional value to be used in conjunction with CodeMirror’s placeholder add-on. */
+    /** Optional lint configuration to be used in conjunction with CodeMirror's linter addon.
+        (* TODO *) lint?: boolean | LintOptions;
+        Optional value to be used in conjunction with CodeMirror’s placeholder add-on. */
     [@bs.optional]
     placeholder: string,
     [@bs.optional]


### PR DESCRIPTION
Looks like the `refmt` version used in the project contains a bug that makes the formatted code depend on original code: 
```
$ yarn refmt
...

$ git st
On branch master
Your branch is up to date with 'origin/master'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   src_editor/CodeMirror.re

$ yarn refmt 
...

$ git st
On branch master
Your branch is up to date with 'origin/master'.

nothing to commit, working tree clean
```

This PR is a quickfix: it just changes formatting of comments to not trigger this behavior of refmt.