### PR TITLE
Add checkbox with live reload when opening sketches of other users

### DIFF
--- a/client/src/Note.re
+++ b/client/src/Note.re
@@ -24,7 +24,11 @@ let make = (~noteInfo: Route.noteRouteConfig) => {
   let noteQuery = GetNoteById.make(~noteId, ());
 
   <GetNoteByIdComponent variables=noteQuery##variables>
-    ...{({result}) =>
+    ...{({refetch, result}) => {
+    let refetch: option(unit => Js.Promise.t('g)), "title": option(string) = Some(
+                                    () =>
+                                      refetch(Some(noteQuery##variables)),
+                                  );
       switch (result) {
       | Loading => <Editor_NotePlaceholder />
       | Error(error) => error.message->str
@@ -69,6 +73,7 @@ let make = (~noteInfo: Route.noteRouteConfig) => {
                                 blocks
                                 forkFrom=?{note##fork_from}
                                 hasSavePermission
+                                refetch=refetch
                               />
                          </RedirectSketchURL>;
                        }}
@@ -76,7 +81,7 @@ let make = (~noteInfo: Route.noteRouteConfig) => {
                    },
                  )
                );
-      }
+      }}
     }
   </GetNoteByIdComponent>;
 };

--- a/client/src_editor/Editor_Note.re
+++ b/client/src_editor/Editor_Note.re
@@ -118,6 +118,7 @@ module Editor_Note = {
         ~initialNoteOwnerId: id,
         ~initialNoteLastEdited: option(Js.Json.t),
         ~registerShortcut: Shortcut.subscribeFun,
+        ~refetch=None,
       ) => {
     let ({editorContentStatus, lang} as state, dispatch) =
       React.useReducer(
@@ -189,6 +190,32 @@ module Editor_Note = {
         None;
       },
       [|state.noteId|],
+    );
+
+    React.useEffect1(
+      () => {
+        switch (refetch) {
+        | None => None
+        | Some(refetch) =>
+          let intervalId =
+            Js.Global.setInterval(
+              () => {
+                refetch()
+                ->Js.Promise.then_(
+                    value => {
+                      Js.log(value);
+                      Js.Promise.resolve();
+                    },
+                    _,
+                  )
+                ->ignore
+              },
+              5000,
+            );
+          Some(() => Js.Global.clearInterval(intervalId));
+        }
+      },
+      [|refetch|],
     );
 
     <>
@@ -289,6 +316,17 @@ module Editor_Note = {
                  </span>
                </fieldset>
              </UI_Balloon>
+             <div>
+               {React.string("foo")}
+               <input
+                 name="isGoing"
+                 type_="checkbox"
+                 checked=true
+                 onChange={event => {
+                   Webapi.Dom.(event->ReactEvent.Form.preventDefault)
+                 }}
+               />
+             </div>
            </>}
       </UI_Topbar.Actions>
       <Helmet>
@@ -311,7 +349,7 @@ module Editor_Note = {
             <Editor_Note_GetUserInfo userId={state.noteOwnerId}>
               {fun
                | None => React.null
-               | Some((user: Js.t('a))) =>
+               | Some(user: Js.t('a)) =>
                  <UI_SketchOwnerInfo
                    owner=user
                    noteLastEdited=?{state.noteLastEdited}
@@ -398,6 +436,7 @@ module WithShortcut = {
         ~noteOwnerId,
         ~noteLastEdited,
         ~forkFrom=?,
+        ~refetch,
       ) =>
     ReactCompat.useRecordApi({
       ...ReactCompat.component,
@@ -417,6 +456,7 @@ module WithShortcut = {
                initialNoteLastEdited=noteLastEdited
                initialForkFrom=?forkFrom
                registerShortcut
+               refetch
              />}
         </Shortcut.Consumer>,
     });


### PR DESCRIPTION
Adds a checkbox so that when it's enabled, Sketch will reload the note content every 5 secs. Useful for live sessions, meetups, etc.